### PR TITLE
chore: regenerate packages in google-cloud-[a-d], copyright changes only

### DIFF
--- a/packages/google-cloud-access-approval/.flake8
+++ b/packages/google-cloud-access-approval/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/MANIFEST.in
+++ b/packages/google-cloud-access-approval/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval/__init__.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval/gapic_version.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/gapic_version.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/__init__.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/__init__.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/async_client.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/client.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/pagers.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/__init__.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/base.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/grpc.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/grpc_asyncio.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/rest.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/rest_base.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/types/__init__.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/types/accessapproval.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/types/accessapproval.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_approve_approval_request_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_approve_approval_request_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_approve_approval_request_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_approve_approval_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_delete_access_approval_settings_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_delete_access_approval_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_delete_access_approval_settings_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_delete_access_approval_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_dismiss_approval_request_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_dismiss_approval_request_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_dismiss_approval_request_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_dismiss_approval_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_service_account_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_service_account_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_settings_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_settings_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_approval_request_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_approval_request_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_approval_request_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_approval_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_invalidate_approval_request_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_invalidate_approval_request_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_invalidate_approval_request_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_invalidate_approval_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_list_approval_requests_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_list_approval_requests_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_list_approval_requests_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_list_approval_requests_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_update_access_approval_settings_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_update_access_approval_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_update_access_approval_settings_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_update_access_approval_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/tests/__init__.py
+++ b/packages/google-cloud-access-approval/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/tests/unit/__init__.py
+++ b/packages/google-cloud-access-approval/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-access-approval/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/tests/unit/gapic/accessapproval_v1/__init__.py
+++ b/packages/google-cloud-access-approval/tests/unit/gapic/accessapproval_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/.flake8
+++ b/packages/google-cloud-advisorynotifications/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/MANIFEST.in
+++ b/packages/google-cloud-advisorynotifications/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications/__init__.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications/gapic_version.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/gapic_version.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/__init__.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/__init__.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/async_client.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/client.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/pagers.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/__init__.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/base.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/grpc.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/rest.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/rest_base.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/types/__init__.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/types/service.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_notification_async.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_notification_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_notification_sync.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_notification_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_settings_async.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_settings_sync.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_list_notifications_async.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_list_notifications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_list_notifications_sync.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_list_notifications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_update_settings_async.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_update_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_update_settings_sync.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_update_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/tests/__init__.py
+++ b/packages/google-cloud-advisorynotifications/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/tests/unit/__init__.py
+++ b/packages/google-cloud-advisorynotifications/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-advisorynotifications/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/tests/unit/gapic/advisorynotifications_v1/__init__.py
+++ b/packages/google-cloud-advisorynotifications/tests/unit/gapic/advisorynotifications_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/.flake8
+++ b/packages/google-cloud-alloydb-connectors/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/MANIFEST.in
+++ b/packages/google-cloud-alloydb-connectors/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors/gapic_version.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/gapic_version.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/services/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/types/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/types/resources.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/gapic_version.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/services/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/types/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/types/resources.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/gapic_version.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/services/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/types/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/types/resources.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/unit/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1alpha/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1beta/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/.flake8
+++ b/packages/google-cloud-alloydb/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/MANIFEST.in
+++ b/packages/google-cloud-alloydb/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb/gapic_version.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/gapic_version.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/pagers.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/csql_resources.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/csql_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/csql_service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/csql_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/data_model.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/data_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/gapic_version.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/pagers.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/csql_resources.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/csql_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/csql_service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/csql_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/data_model.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/data_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/gemini.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/gemini.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/gapic_version.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/pagers.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/csql_resources.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/csql_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/csql_service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/csql_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/data_model.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/data_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/gemini.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/gemini.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_batch_create_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_batch_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_secondary_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_secondary_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_secondary_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_secondary_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_execute_sql_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_execute_sql_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_execute_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_execute_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_export_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_export_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_failover_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_failover_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_generate_client_certificate_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_generate_client_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_generate_client_certificate_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_generate_client_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_backup_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_cluster_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_connection_info_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_connection_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_connection_info_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_connection_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_instance_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_import_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_import_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_inject_fault_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_inject_fault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_backups_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_backups_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_clusters_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_clusters_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_databases_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_databases_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_instances_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_supported_database_flags_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_supported_database_flags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_supported_database_flags_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_supported_database_flags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_users_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_users_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_promote_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_promote_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_restart_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_restart_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_restore_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_restore_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_switchover_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_switchover_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_upgrade_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_upgrade_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_batch_create_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_batch_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_database_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_database_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_secondary_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_secondary_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_secondary_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_secondary_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_execute_sql_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_execute_sql_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_execute_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_execute_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_export_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_export_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_failover_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_failover_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_generate_client_certificate_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_generate_client_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_generate_client_certificate_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_generate_client_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_backup_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_cluster_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_connection_info_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_connection_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_connection_info_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_connection_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_instance_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_import_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_import_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_inject_fault_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_inject_fault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_backups_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_backups_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_clusters_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_clusters_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_databases_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_databases_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_instances_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_supported_database_flags_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_supported_database_flags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_supported_database_flags_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_supported_database_flags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_users_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_users_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_promote_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_promote_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_restart_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_restart_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_restore_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_restore_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_switchover_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_switchover_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_upgrade_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_upgrade_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_batch_create_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_batch_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_database_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_database_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_secondary_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_secondary_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_secondary_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_secondary_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_execute_sql_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_execute_sql_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_execute_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_execute_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_export_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_export_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_failover_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_failover_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_generate_client_certificate_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_generate_client_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_generate_client_certificate_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_generate_client_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_backup_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_cluster_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_connection_info_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_connection_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_connection_info_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_connection_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_instance_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_import_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_import_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_inject_fault_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_inject_fault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_backups_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_backups_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_clusters_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_clusters_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_databases_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_databases_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_instances_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_supported_database_flags_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_supported_database_flags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_supported_database_flags_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_supported_database_flags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_users_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_users_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_promote_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_promote_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_restart_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_restart_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_restore_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_restore_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_switchover_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_switchover_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_upgrade_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_upgrade_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/__init__.py
+++ b/packages/google-cloud-alloydb/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/unit/__init__.py
+++ b/packages/google-cloud-alloydb/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-alloydb/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1/__init__.py
+++ b/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1alpha/__init__.py
+++ b/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1beta/__init__.py
+++ b/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/.flake8
+++ b/packages/google-cloud-api-gateway/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/MANIFEST.in
+++ b/packages/google-cloud-api-gateway/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway/__init__.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway/gapic_version.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/gapic_version.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/__init__.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/__init__.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/client.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/pagers.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/__init__.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/base.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/grpc.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/rest.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/rest_base.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/__init__.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/apigateway.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/apigateway.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/apigateway_service.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/apigateway_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_api_config_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_api_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_api_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_gateway_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_api_config_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_api_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_api_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_gateway_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_config_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_config_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_gateway_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_gateway_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_gateway_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_api_configs_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_api_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_api_configs_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_api_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_apis_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_apis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_apis_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_apis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_gateways_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_gateways_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_gateways_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_gateways_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_api_config_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_api_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_api_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_gateway_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/tests/__init__.py
+++ b/packages/google-cloud-api-gateway/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/tests/unit/__init__.py
+++ b/packages/google-cloud-api-gateway/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-api-gateway/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/tests/unit/gapic/apigateway_v1/__init__.py
+++ b/packages/google-cloud-api-gateway/tests/unit/gapic/apigateway_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/.flake8
+++ b/packages/google-cloud-api-keys/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/MANIFEST.in
+++ b/packages/google-cloud-api-keys/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys/__init__.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys/gapic_version.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/gapic_version.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/__init__.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/__init__.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/client.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/pagers.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/__init__.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/base.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/grpc.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/grpc_asyncio.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/rest.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/rest_base.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/__init__.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/apikeys.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/apikeys.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/resources.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_create_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_create_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_delete_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_delete_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_async.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_string_async.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_string_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_string_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_string_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_list_keys_async.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_list_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_list_keys_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_list_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_lookup_key_async.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_lookup_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_lookup_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_lookup_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_undelete_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_undelete_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_update_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_update_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/tests/__init__.py
+++ b/packages/google-cloud-api-keys/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/tests/unit/__init__.py
+++ b/packages/google-cloud-api-keys/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-api-keys/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/tests/unit/gapic/api_keys_v2/__init__.py
+++ b/packages/google-cloud-api-keys/tests/unit/gapic/api_keys_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/.flake8
+++ b/packages/google-cloud-apigee-connect/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/MANIFEST.in
+++ b/packages/google-cloud-apigee-connect/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect/gapic_version.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/gapic_version.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/async_client.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/client.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/pagers.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/base.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/grpc.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/async_client.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/client.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/base.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/grpc.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/connection.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/tether.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/tether.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_connection_service_list_connections_async.py
+++ b/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_connection_service_list_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_connection_service_list_connections_sync.py
+++ b/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_connection_service_list_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_tether_egress_async.py
+++ b/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_tether_egress_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_tether_egress_sync.py
+++ b/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_tether_egress_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/tests/__init__.py
+++ b/packages/google-cloud-apigee-connect/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/tests/unit/__init__.py
+++ b/packages/google-cloud-apigee-connect/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-apigee-connect/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/tests/unit/gapic/apigeeconnect_v1/__init__.py
+++ b/packages/google-cloud-apigee-connect/tests/unit/gapic/apigeeconnect_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/.flake8
+++ b/packages/google-cloud-apigee-registry/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/MANIFEST.in
+++ b/packages/google-cloud-apigee-registry/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry/gapic_version.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/gapic_version.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/client.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/base.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/grpc.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/rest.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/rest_base.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/async_client.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/client.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/pagers.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/base.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/grpc.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/rest.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/rest_base.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/provisioning_service.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/provisioning_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/registry_models.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/registry_models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/registry_service.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/registry_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_create_instance_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_delete_instance_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_get_instance_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_get_instance_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_deployment_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_deployment_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_spec_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_spec_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_version_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_version_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_artifact_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_artifact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_artifact_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_revision_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_revision_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_revision_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_revision_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_version_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_version_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_artifact_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_artifact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_artifact_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_deployment_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_deployment_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_contents_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_contents_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_version_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_version_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_contents_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_contents_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployment_revisions_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployment_revisions_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployments_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployments_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_spec_revisions_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_spec_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_spec_revisions_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_spec_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_specs_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_specs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_specs_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_specs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_versions_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_versions_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_apis_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_apis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_apis_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_apis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_artifacts_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_artifacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_artifacts_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_replace_artifact_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_replace_artifact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_replace_artifact_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_replace_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_deployment_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_deployment_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_spec_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_spec_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_deployment_revision_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_deployment_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_deployment_revision_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_deployment_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_spec_revision_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_spec_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_spec_revision_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_spec_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_deployment_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_deployment_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_spec_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_spec_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_version_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_version_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/tests/__init__.py
+++ b/packages/google-cloud-apigee-registry/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/tests/unit/__init__.py
+++ b/packages/google-cloud-apigee-registry/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-apigee-registry/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/tests/unit/gapic/apigee_registry_v1/__init__.py
+++ b/packages/google-cloud-apigee-registry/tests/unit/gapic/apigee_registry_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/.flake8
+++ b/packages/google-cloud-apihub/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/MANIFEST.in
+++ b/packages/google-cloud-apihub/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub/gapic_version.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/gapic_version.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/apihub_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/apihub_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/collect_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/collect_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/common_fields.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/common_fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/curate_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/curate_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/discovery_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/discovery_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/host_project_registration_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/host_project_registration_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/linting_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/linting_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/plugin_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/plugin_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/provisioning_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/provisioning_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/runtime_project_attachment_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/runtime_project_attachment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_collect_collect_api_data_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_collect_collect_api_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_operation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_operation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_attribute_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_attribute_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_deployment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_deployment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_external_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_external_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_external_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_external_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_spec_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_spec_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_version_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_version_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_create_curation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_create_curation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_create_curation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_create_curation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_delete_curation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_delete_curation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_delete_curation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_delete_curation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_get_curation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_get_curation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_get_curation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_get_curation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_list_curations_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_list_curations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_list_curations_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_list_curations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_update_curation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_update_curation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_update_curation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_update_curation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_operation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_operation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_attribute_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_attribute_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_deployment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_deployment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_external_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_external_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_external_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_external_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_spec_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_spec_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_version_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_version_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_create_dependency_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_create_dependency_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_create_dependency_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_create_dependency_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_delete_dependency_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_delete_dependency_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_delete_dependency_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_delete_dependency_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_get_dependency_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_get_dependency_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_get_dependency_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_get_dependency_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_list_dependencies_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_list_dependencies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_list_dependencies_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_list_dependencies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_update_dependency_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_update_dependency_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_update_dependency_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_update_dependency_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_observation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_observation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_observation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_observation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_operation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_operation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_observations_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_observations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_observations_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_observations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_operations_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_operations_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_operation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_operation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_attribute_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_attribute_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_definition_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_definition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_definition_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_definition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_deployment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_deployment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_external_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_external_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_external_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_external_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_contents_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_contents_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_version_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_version_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_api_operations_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_api_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_api_operations_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_api_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_apis_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_apis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_apis_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_apis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_attributes_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_attributes_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_deployments_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_deployments_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_external_apis_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_external_apis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_external_apis_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_external_apis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_specs_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_specs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_specs_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_specs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_versions_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_versions_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_delete_plugin_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_delete_plugin_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_delete_plugin_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_delete_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_instance_action_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_instance_action_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_instance_action_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_instance_action_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_execute_plugin_instance_action_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_execute_plugin_instance_action_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_instance_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugin_instances_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugin_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugin_instances_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugin_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugins_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugins_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugins_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugins_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_update_plugin_instance_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_update_plugin_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_update_plugin_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_update_plugin_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_search_resources_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_search_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_search_resources_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_search_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_operation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_operation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_attribute_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_attribute_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_deployment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_deployment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_external_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_external_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_external_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_external_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_spec_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_spec_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_version_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_version_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_create_host_project_registration_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_create_host_project_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_create_host_project_registration_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_create_host_project_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_get_host_project_registration_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_get_host_project_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_get_host_project_registration_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_get_host_project_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_list_host_project_registrations_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_list_host_project_registrations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_list_host_project_registrations_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_list_host_project_registrations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_contents_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_contents_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_lint_spec_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_lint_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_lint_spec_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_lint_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_update_style_guide_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_update_style_guide_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_update_style_guide_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_update_style_guide_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_create_api_hub_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_create_api_hub_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_delete_api_hub_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_delete_api_hub_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_get_api_hub_instance_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_get_api_hub_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_get_api_hub_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_get_api_hub_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_lookup_api_hub_instance_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_lookup_api_hub_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_lookup_api_hub_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_lookup_api_hub_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_create_runtime_project_attachment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_create_runtime_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_create_runtime_project_attachment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_create_runtime_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_delete_runtime_project_attachment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_delete_runtime_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_delete_runtime_project_attachment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_delete_runtime_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_get_runtime_project_attachment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_get_runtime_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_get_runtime_project_attachment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_get_runtime_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_list_runtime_project_attachments_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_list_runtime_project_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_list_runtime_project_attachments_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_list_runtime_project_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_lookup_runtime_project_attachment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_lookup_runtime_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_lookup_runtime_project_attachment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_lookup_runtime_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/tests/__init__.py
+++ b/packages/google-cloud-apihub/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/tests/unit/__init__.py
+++ b/packages/google-cloud-apihub/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-apihub/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/tests/unit/gapic/apihub_v1/__init__.py
+++ b/packages/google-cloud-apihub/tests/unit/gapic/apihub_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/.flake8
+++ b/packages/google-cloud-apiregistry/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/MANIFEST.in
+++ b/packages/google-cloud-apiregistry/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry/__init__.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry/gapic_version.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/gapic_version.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/__init__.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/__init__.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/async_client.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/client.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/pagers.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/__init__.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/base.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/grpc.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/rest.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/rest_base.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/__init__.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/common.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/resources.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/service.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_server_async.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_server_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_server_sync.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_tool_async.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_tool_sync.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_servers_async.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_servers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_servers_sync.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_servers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_tools_async.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_tools_sync.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/tests/__init__.py
+++ b/packages/google-cloud-apiregistry/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/tests/unit/__init__.py
+++ b/packages/google-cloud-apiregistry/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-apiregistry/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/tests/unit/gapic/apiregistry_v1beta/__init__.py
+++ b/packages/google-cloud-apiregistry/tests/unit/gapic/apiregistry_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/.flake8
+++ b/packages/google-cloud-appengine-admin/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/MANIFEST.in
+++ b/packages/google-cloud-appengine-admin/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin/gapic_version.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/gapic_version.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/async_client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/async_client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/async_client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/app_yaml.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/app_yaml.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/appengine.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/appengine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/application.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/application.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/audit_data.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/audit_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/certificate.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/certificate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/deploy.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/deploy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/deployed_files.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/deployed_files.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/domain.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/domain.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/domain_mapping.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/domain_mapping.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/firewall.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/firewall.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/instance.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/location.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/network_settings.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/network_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/operation.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/operation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/service.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/version.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_create_application_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_create_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_get_application_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_get_application_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_get_application_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_get_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_repair_application_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_repair_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_update_application_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_update_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_create_authorized_certificate_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_create_authorized_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_create_authorized_certificate_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_create_authorized_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_delete_authorized_certificate_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_delete_authorized_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_delete_authorized_certificate_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_delete_authorized_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_get_authorized_certificate_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_get_authorized_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_get_authorized_certificate_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_get_authorized_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_list_authorized_certificates_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_list_authorized_certificates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_list_authorized_certificates_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_list_authorized_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_update_authorized_certificate_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_update_authorized_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_update_authorized_certificate_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_update_authorized_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_domains_list_authorized_domains_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_domains_list_authorized_domains_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_domains_list_authorized_domains_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_domains_list_authorized_domains_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_create_domain_mapping_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_create_domain_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_delete_domain_mapping_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_delete_domain_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_get_domain_mapping_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_get_domain_mapping_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_get_domain_mapping_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_get_domain_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_list_domain_mappings_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_list_domain_mappings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_list_domain_mappings_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_list_domain_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_update_domain_mapping_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_update_domain_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_batch_update_ingress_rules_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_batch_update_ingress_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_batch_update_ingress_rules_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_batch_update_ingress_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_create_ingress_rule_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_create_ingress_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_create_ingress_rule_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_create_ingress_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_delete_ingress_rule_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_delete_ingress_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_delete_ingress_rule_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_delete_ingress_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_get_ingress_rule_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_get_ingress_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_get_ingress_rule_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_get_ingress_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_list_ingress_rules_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_list_ingress_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_list_ingress_rules_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_list_ingress_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_update_ingress_rule_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_update_ingress_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_update_ingress_rule_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_update_ingress_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_debug_instance_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_debug_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_delete_instance_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_get_instance_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_get_instance_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_list_instances_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_list_instances_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_delete_service_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_get_service_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_get_service_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_list_services_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_list_services_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_update_service_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_create_version_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_create_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_delete_version_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_get_version_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_get_version_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_list_versions_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_list_versions_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_update_version_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_update_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/tests/__init__.py
+++ b/packages/google-cloud-appengine-admin/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/tests/unit/__init__.py
+++ b/packages/google-cloud-appengine-admin/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-appengine-admin/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/tests/unit/gapic/appengine_admin_v1/__init__.py
+++ b/packages/google-cloud-appengine-admin/tests/unit/gapic/appengine_admin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/.flake8
+++ b/packages/google-cloud-appengine-logging/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/MANIFEST.in
+++ b/packages/google-cloud-appengine-logging/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging/__init__.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging/gapic_version.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/gapic_version.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/services/__init__.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/types/__init__.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/types/request_log.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/types/request_log.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/tests/__init__.py
+++ b/packages/google-cloud-appengine-logging/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/tests/unit/__init__.py
+++ b/packages/google-cloud-appengine-logging/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-appengine-logging/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/tests/unit/gapic/appengine_logging_v1/__init__.py
+++ b/packages/google-cloud-appengine-logging/tests/unit/gapic/appengine_logging_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/.flake8
+++ b/packages/google-cloud-apphub/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/MANIFEST.in
+++ b/packages/google-cloud-apphub/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub/__init__.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub/gapic_version.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/gapic_version.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/__init__.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/__init__.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/client.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/pagers.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/__init__.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/base.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/grpc.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/rest.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/rest_base.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/__init__.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/apphub_service.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/apphub_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/application.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/application.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/attributes.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/service.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/service_project_attachment.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/service_project_attachment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/workload.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/workload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_application_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_service_project_attachment_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_service_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_application_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_service_project_attachment_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_service_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_detach_service_project_attachment_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_detach_service_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_detach_service_project_attachment_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_detach_service_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_application_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_application_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_application_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_service_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_workload_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_project_attachment_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_project_attachment_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_workload_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_applications_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_applications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_applications_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_services_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_services_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_workloads_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_workloads_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_service_project_attachments_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_service_project_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_service_project_attachments_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_service_project_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_services_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_services_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_workloads_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_workloads_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_service_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_workload_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_service_project_attachment_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_service_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_service_project_attachment_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_service_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_application_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/tests/__init__.py
+++ b/packages/google-cloud-apphub/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/tests/unit/__init__.py
+++ b/packages/google-cloud-apphub/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-apphub/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/tests/unit/gapic/apphub_v1/__init__.py
+++ b/packages/google-cloud-apphub/tests/unit/gapic/apphub_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/.flake8
+++ b/packages/google-cloud-appoptimize/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/MANIFEST.in
+++ b/packages/google-cloud-appoptimize/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize/__init__.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize/gapic_version.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/gapic_version.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/__init__.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/__init__.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/client.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/pagers.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/__init__.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/base.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/grpc.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/rest.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/rest_base.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/types/__init__.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/types/app_optimize.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/types/app_optimize.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_create_report_sync.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_create_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_delete_report_async.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_delete_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_delete_report_sync.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_delete_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_get_report_async.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_get_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_get_report_sync.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_get_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_list_reports_async.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_list_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_list_reports_sync.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_list_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_read_report_async.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_read_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_read_report_sync.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_read_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/tests/__init__.py
+++ b/packages/google-cloud-appoptimize/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/tests/unit/__init__.py
+++ b/packages/google-cloud-appoptimize/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-appoptimize/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/tests/unit/gapic/appoptimize_v1beta/__init__.py
+++ b/packages/google-cloud-appoptimize/tests/unit/gapic/appoptimize_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/.flake8
+++ b/packages/google-cloud-artifact-registry/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/MANIFEST.in
+++ b/packages/google-cloud-artifact-registry/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry/gapic_version.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/gapic_version.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/client.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/pagers.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/base.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/grpc.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/rest.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/rest_base.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/apt_artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/apt_artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/attachment.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/attachment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/export.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/file.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/generic.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/generic.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/go.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/go.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/kfp_artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/kfp_artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/package.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/package.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/repository.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/repository.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/rule.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/service.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/settings.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/tag.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/tag.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/version.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/vpcsc_config.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/vpcsc_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/yum_artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/yum_artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/gapic_version.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/client.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/pagers.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/base.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/grpc.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/rest.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/rest_base.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/apt_artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/apt_artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/file.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/package.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/package.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/repository.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/repository.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/service.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/settings.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/tag.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/tag.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/version.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/yum_artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/yum_artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_batch_delete_versions_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_batch_delete_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_attachment_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_rule_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_rule_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_attachment_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_file_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_rule_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_rule_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_version_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_export_artifact_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_export_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_attachment_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_attachment_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_docker_image_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_docker_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_docker_image_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_docker_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_file_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_file_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_iam_policy_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_iam_policy_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_maven_artifact_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_maven_artifact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_maven_artifact_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_maven_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_npm_package_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_npm_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_npm_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_npm_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_package_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_project_settings_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_project_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_project_settings_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_project_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_python_package_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_python_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_python_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_python_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_repository_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_rule_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_rule_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_version_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_version_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_vpcsc_config_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_vpcsc_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_vpcsc_config_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_vpcsc_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_import_apt_artifacts_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_import_apt_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_import_yum_artifacts_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_import_yum_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_attachments_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_attachments_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_docker_images_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_docker_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_docker_images_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_docker_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_files_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_files_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_maven_artifacts_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_maven_artifacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_maven_artifacts_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_maven_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_npm_packages_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_npm_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_npm_packages_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_npm_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_packages_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_packages_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_python_packages_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_python_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_python_packages_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_python_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_repositories_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_repositories_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_rules_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_rules_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_tags_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_tags_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_versions_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_versions_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_set_iam_policy_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_set_iam_policy_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_test_iam_permissions_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_test_iam_permissions_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_file_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_file_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_package_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_project_settings_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_project_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_project_settings_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_project_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_repository_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_rule_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_rule_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_version_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_version_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_vpcsc_config_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_vpcsc_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_vpcsc_config_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_vpcsc_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_version_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_file_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_file_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_iam_policy_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_iam_policy_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_package_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_project_settings_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_project_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_project_settings_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_project_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_repository_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_version_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_version_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_import_apt_artifacts_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_import_apt_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_import_yum_artifacts_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_import_yum_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_files_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_files_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_packages_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_packages_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_repositories_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_repositories_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_tags_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_tags_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_versions_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_versions_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_set_iam_policy_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_set_iam_policy_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_test_iam_permissions_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_test_iam_permissions_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_project_settings_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_project_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_project_settings_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_project_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_repository_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/tests/__init__.py
+++ b/packages/google-cloud-artifact-registry/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/tests/unit/__init__.py
+++ b/packages/google-cloud-artifact-registry/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-artifact-registry/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/tests/unit/gapic/artifactregistry_v1/__init__.py
+++ b/packages/google-cloud-artifact-registry/tests/unit/gapic/artifactregistry_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/tests/unit/gapic/artifactregistry_v1beta2/__init__.py
+++ b/packages/google-cloud-artifact-registry/tests/unit/gapic/artifactregistry_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/.flake8
+++ b/packages/google-cloud-asset/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/MANIFEST.in
+++ b/packages/google-cloud-asset/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset/gapic_version.py
+++ b/packages/google-cloud-asset/google/cloud/asset/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/gapic_version.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/pagers.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/grpc.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/rest_base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/types/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/types/asset_enrichment_resourceowners.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/types/asset_enrichment_resourceowners.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/types/asset_service.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/types/asset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/types/assets.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/types/assets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/gapic_version.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/async_client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/pagers.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/grpc.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/rest.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/rest_base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/asset_service.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/asset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/assets.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/assets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/gapic_version.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/async_client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/grpc.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/rest.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/rest_base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/asset_service.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/asset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/assets.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/assets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/gapic_version.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/async_client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/pagers.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/grpc.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/rest.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/rest_base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/asset_service.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/asset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/assets.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/assets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_longrunning_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_longrunning_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_saved_query_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_saved_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_saved_query_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_saved_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_export_assets_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_export_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_iam_policies_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_iam_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_iam_policies_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_iam_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_resources_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_resources_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_create_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_create_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_create_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_create_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_delete_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_delete_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_delete_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_delete_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_get_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_get_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_get_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_get_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_list_feeds_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_list_feeds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_list_feeds_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_list_feeds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_update_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_update_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_update_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_update_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p5beta1_generated_asset_service_list_assets_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p5beta1_generated_asset_service_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p5beta1_generated_asset_service_list_assets_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p5beta1_generated_asset_service_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/__init__.py
+++ b/packages/google-cloud-asset/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/gapic/asset_v1/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/gapic/asset_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/gapic/asset_v1p1beta1/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/gapic/asset_v1p1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/gapic/asset_v1p2beta1/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/gapic/asset_v1p2beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/gapic/asset_v1p5beta1/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/gapic/asset_v1p5beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/.flake8
+++ b/packages/google-cloud-assured-workloads/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/MANIFEST.in
+++ b/packages/google-cloud-assured-workloads/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads/gapic_version.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/gapic_version.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/client.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/pagers.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/base.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/grpc.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/rest.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/rest_base.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/types/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/types/assuredworkloads.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/types/assuredworkloads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/gapic_version.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/client.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/pagers.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/base.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/grpc.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/rest.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/rest_base.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/assuredworkloads.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/assuredworkloads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/assuredworkloads_service.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/assuredworkloads_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_acknowledge_violation_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_acknowledge_violation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_acknowledge_violation_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_acknowledge_violation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_create_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_create_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_delete_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_delete_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_delete_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_delete_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_violation_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_violation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_violation_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_violation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_violations_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_violations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_violations_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_violations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_workloads_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_workloads_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_restrict_allowed_resources_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_restrict_allowed_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_restrict_allowed_resources_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_restrict_allowed_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_update_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_update_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_update_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_update_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_analyze_workload_move_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_analyze_workload_move_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_analyze_workload_move_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_analyze_workload_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_create_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_create_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_delete_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_delete_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_delete_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_delete_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_get_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_get_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_get_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_get_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_list_workloads_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_list_workloads_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_restrict_allowed_resources_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_restrict_allowed_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_restrict_allowed_resources_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_restrict_allowed_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_update_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_update_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_update_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_update_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/tests/__init__.py
+++ b/packages/google-cloud-assured-workloads/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/tests/unit/__init__.py
+++ b/packages/google-cloud-assured-workloads/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-assured-workloads/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/tests/unit/gapic/assuredworkloads_v1/__init__.py
+++ b/packages/google-cloud-assured-workloads/tests/unit/gapic/assuredworkloads_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/tests/unit/gapic/assuredworkloads_v1beta1/__init__.py
+++ b/packages/google-cloud-assured-workloads/tests/unit/gapic/assuredworkloads_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/.flake8
+++ b/packages/google-cloud-auditmanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/MANIFEST.in
+++ b/packages/google-cloud-auditmanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager/__init__.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager/gapic_version.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/gapic_version.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/__init__.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/__init__.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/client.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/pagers.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/__init__.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/base.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/grpc.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/rest.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/rest_base.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/types/__init__.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/types/auditmanager.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/types/auditmanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_enroll_resource_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_enroll_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_enroll_resource_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_enroll_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_report_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_scope_report_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_scope_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_scope_report_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_scope_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_audit_report_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_audit_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_audit_report_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_audit_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_resource_enrollment_status_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_resource_enrollment_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_resource_enrollment_status_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_resource_enrollment_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_audit_reports_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_audit_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_audit_reports_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_audit_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_controls_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_controls_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_resource_enrollment_statuses_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_resource_enrollment_statuses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_resource_enrollment_statuses_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_resource_enrollment_statuses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/tests/__init__.py
+++ b/packages/google-cloud-auditmanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/tests/unit/__init__.py
+++ b/packages/google-cloud-auditmanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-auditmanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/tests/unit/gapic/auditmanager_v1/__init__.py
+++ b/packages/google-cloud-auditmanager/tests/unit/gapic/auditmanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/.flake8
+++ b/packages/google-cloud-automl/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/MANIFEST.in
+++ b/packages/google-cloud-automl/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl/gapic_version.py
+++ b/packages/google-cloud-automl/google/cloud/automl/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/gapic_version.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/client.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/pagers.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/grpc.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/grpc_asyncio.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/rest.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/rest_base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/client.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/annotation_payload.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/annotation_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/annotation_spec.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/annotation_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/classification.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/classification.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/data_items.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/data_items.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/dataset.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/detection.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/geometry.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/image.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/model.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/model_evaluation.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/model_evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/operations.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/prediction_service.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/service.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/text.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/text.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/text_extraction.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/text_extraction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/text_segment.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/text_segment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/text_sentiment.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/text_sentiment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/translation.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/translation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/gapic_version.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/client.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/pagers.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/grpc.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/grpc_asyncio.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/rest.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/rest_base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/client.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/annotation_payload.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/annotation_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/annotation_spec.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/annotation_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/classification.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/classification.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/column_spec.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/column_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_items.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_items.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_stats.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_stats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_types.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/dataset.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/detection.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/geometry.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/image.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/io.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/io.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/model.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/model_evaluation.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/model_evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/operations.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/prediction_service.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/ranges.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/ranges.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/regression.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/regression.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/service.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/table_spec.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/table_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/tables.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/tables.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/temporal.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/temporal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_extraction.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_extraction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_segment.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_segment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_sentiment.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_sentiment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/translation.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/translation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/video.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/video.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_create_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_create_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_delete_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_delete_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_deploy_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_deploy_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_export_data_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_export_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_export_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_annotation_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_annotation_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_annotation_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_annotation_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_dataset_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_evaluation_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_evaluation_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_import_data_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_datasets_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_datasets_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_model_evaluations_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_model_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_model_evaluations_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_model_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_models_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_models_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_undeploy_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_undeploy_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_dataset_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_model_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_batch_predict_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_batch_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_dataset_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_delete_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_delete_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_deploy_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_deploy_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_data_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_evaluated_examples_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_evaluated_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_annotation_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_annotation_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_annotation_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_annotation_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_column_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_column_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_column_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_column_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_dataset_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_evaluation_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_evaluation_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_table_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_table_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_table_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_table_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_import_data_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_column_specs_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_column_specs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_column_specs_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_column_specs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_datasets_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_datasets_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_model_evaluations_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_model_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_model_evaluations_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_model_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_models_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_models_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_table_specs_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_table_specs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_table_specs_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_table_specs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_undeploy_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_undeploy_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_column_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_column_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_column_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_column_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_dataset_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_table_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_table_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_table_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_table_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_batch_predict_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_batch_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/tests/__init__.py
+++ b/packages/google-cloud-automl/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/tests/unit/__init__.py
+++ b/packages/google-cloud-automl/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-automl/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/tests/unit/gapic/automl_v1/__init__.py
+++ b/packages/google-cloud-automl/tests/unit/gapic/automl_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/tests/unit/gapic/automl_v1beta1/__init__.py
+++ b/packages/google-cloud-automl/tests/unit/gapic/automl_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/.flake8
+++ b/packages/google-cloud-backupdr/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/MANIFEST.in
+++ b/packages/google-cloud-backupdr/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr/gapic_version.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/gapic_version.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/client.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/pagers.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/base.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/grpc.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/grpc_asyncio.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/rest.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/rest_base.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/async_client.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/client.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/pagers.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/base.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/grpc.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/grpc_asyncio.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/rest.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/rest_base.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupdr.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupdr.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupplan.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupplan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupplanassociation.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupplanassociation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_alloydb.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_alloydb.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_ba.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_ba.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_cloudsql.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_cloudsql.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_disk.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_disk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_gce.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_gce.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/datasourcereference.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/datasourcereference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/protection_summary.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/protection_summary.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_plan_association_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_plan_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_plan_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_vault_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_management_server_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_management_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_plan_association_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_plan_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_plan_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_vault_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_management_server_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_management_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backup_plan_associations_for_resource_type_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backup_plan_associations_for_resource_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backup_plan_associations_for_resource_type_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backup_plan_associations_for_resource_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backups_for_resource_type_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backups_for_resource_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backups_for_resource_type_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backups_for_resource_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_data_source_references_for_resource_type_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_data_source_references_for_resource_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_data_source_references_for_resource_type_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_data_source_references_for_resource_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_usable_backup_vaults_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_usable_backup_vaults_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_usable_backup_vaults_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_usable_backup_vaults_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_association_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_association_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_revision_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_revision_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_vault_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_vault_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_vault_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_reference_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_reference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_reference_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_reference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_management_server_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_management_server_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_management_server_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_management_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_initialize_service_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_initialize_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_associations_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_associations_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_revisions_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_revisions_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plans_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plans_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plans_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plans_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_vaults_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_vaults_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_vaults_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_vaults_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backups_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backups_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_source_references_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_source_references_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_source_references_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_source_references_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_sources_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_sources_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_management_servers_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_management_servers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_management_servers_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_management_servers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_protection_summary_list_resource_backup_configs_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_protection_summary_list_resource_backup_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_protection_summary_list_resource_backup_configs_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_protection_summary_list_resource_backup_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_restore_backup_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_restore_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_trigger_backup_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_trigger_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_plan_association_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_plan_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_plan_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_vault_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_data_source_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/tests/__init__.py
+++ b/packages/google-cloud-backupdr/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/tests/unit/__init__.py
+++ b/packages/google-cloud-backupdr/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-backupdr/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/tests/unit/gapic/backupdr_v1/__init__.py
+++ b/packages/google-cloud-backupdr/tests/unit/gapic/backupdr_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/.flake8
+++ b/packages/google-cloud-bare-metal-solution/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/MANIFEST.in
+++ b/packages/google-cloud-bare-metal-solution/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution/gapic_version.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/gapic_version.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/client.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/pagers.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/base.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/grpc.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/rest.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/rest_base.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/baremetalsolution.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/baremetalsolution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/common.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/instance.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/lun.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/lun.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/network.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/network.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/nfs_share.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/nfs_share.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/osimage.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/osimage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/provisioning.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/provisioning.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/ssh_key.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/ssh_key.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/volume.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/volume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/volume_snapshot.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/volume_snapshot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_nfs_share_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_nfs_share_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_provisioning_config_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_provisioning_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_provisioning_config_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_provisioning_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_ssh_key_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_ssh_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_ssh_key_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_ssh_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_volume_snapshot_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_volume_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_volume_snapshot_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_volume_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_nfs_share_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_nfs_share_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_ssh_key_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_ssh_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_ssh_key_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_ssh_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_volume_snapshot_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_volume_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_volume_snapshot_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_volume_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_detach_lun_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_detach_lun_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_disable_interactive_serial_console_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_disable_interactive_serial_console_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_enable_interactive_serial_console_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_enable_interactive_serial_console_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_evict_lun_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_evict_lun_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_evict_volume_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_evict_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_instance_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_lun_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_lun_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_lun_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_lun_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_network_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_network_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_nfs_share_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_nfs_share_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_nfs_share_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_nfs_share_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_provisioning_config_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_provisioning_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_provisioning_config_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_provisioning_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_snapshot_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_snapshot_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_instances_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_instances_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_luns_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_luns_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_luns_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_luns_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_network_usage_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_network_usage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_network_usage_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_network_usage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_networks_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_networks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_networks_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_networks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_nfs_shares_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_nfs_shares_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_nfs_shares_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_nfs_shares_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_os_images_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_os_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_os_images_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_os_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_provisioning_quotas_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_provisioning_quotas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_provisioning_quotas_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_provisioning_quotas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_ssh_keys_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_ssh_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_ssh_keys_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_ssh_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volume_snapshots_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volume_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volume_snapshots_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volume_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volumes_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volumes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volumes_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volumes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_instance_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_network_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_network_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_nfs_share_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_nfs_share_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_nfs_share_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_nfs_share_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_volume_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_volume_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_volume_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_reset_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_reset_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_resize_volume_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_resize_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_restore_volume_snapshot_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_restore_volume_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_start_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_start_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_stop_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_stop_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_submit_provisioning_config_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_submit_provisioning_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_submit_provisioning_config_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_submit_provisioning_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_network_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_nfs_share_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_nfs_share_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_provisioning_config_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_provisioning_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_provisioning_config_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_provisioning_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_volume_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/tests/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/tests/unit/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/tests/unit/gapic/bare_metal_solution_v2/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/tests/unit/gapic/bare_metal_solution_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/.flake8
+++ b/packages/google-cloud-batch/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/MANIFEST.in
+++ b/packages/google-cloud-batch/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch/gapic_version.py
+++ b/packages/google-cloud-batch/google/cloud/batch/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/gapic_version.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/client.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/pagers.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/base.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/grpc.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/rest.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/rest_base.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/types/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/types/batch.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/types/batch.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/types/job.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/types/task.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/types/volume.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/types/volume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/gapic_version.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/client.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/pagers.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/base.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/grpc.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/rest.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/rest_base.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/batch.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/batch.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/job.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/notification.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/notification.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/resource_allowance.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/resource_allowance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/task.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/volume.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/volume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_cancel_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_cancel_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_create_job_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_create_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_delete_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_job_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_task_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_task_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_jobs_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_jobs_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_tasks_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_tasks_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_cancel_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_cancel_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_job_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_resource_allowance_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_resource_allowance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_resource_allowance_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_resource_allowance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_delete_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_delete_resource_allowance_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_delete_resource_allowance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_job_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_resource_allowance_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_resource_allowance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_resource_allowance_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_resource_allowance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_task_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_task_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_jobs_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_jobs_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_resource_allowances_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_resource_allowances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_resource_allowances_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_resource_allowances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_tasks_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_tasks_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_job_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_resource_allowance_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_resource_allowance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_resource_allowance_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_resource_allowance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/tests/__init__.py
+++ b/packages/google-cloud-batch/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/tests/unit/__init__.py
+++ b/packages/google-cloud-batch/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-batch/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/tests/unit/gapic/batch_v1/__init__.py
+++ b/packages/google-cloud-batch/tests/unit/gapic/batch_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/tests/unit/gapic/batch_v1alpha/__init__.py
+++ b/packages/google-cloud-batch/tests/unit/gapic/batch_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/.flake8
+++ b/packages/google-cloud-beyondcorp-appconnections/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/MANIFEST.in
+++ b/packages/google-cloud-beyondcorp-appconnections/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/client.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/pagers.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/base.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/grpc.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/rest.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/rest_base.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/types/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/types/app_connections_service.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/types/app_connections_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_create_app_connection_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_create_app_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_delete_app_connection_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_delete_app_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_get_app_connection_async.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_get_app_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_get_app_connection_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_get_app_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_list_app_connections_async.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_list_app_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_list_app_connections_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_list_app_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_resolve_app_connections_async.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_resolve_app_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_resolve_app_connections_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_resolve_app_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_update_app_connection_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_update_app_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/tests/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/tests/unit/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/tests/unit/gapic/beyondcorp_appconnections_v1/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/tests/unit/gapic/beyondcorp_appconnections_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/.flake8
+++ b/packages/google-cloud-beyondcorp-appconnectors/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/MANIFEST.in
+++ b/packages/google-cloud-beyondcorp-appconnectors/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/client.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/pagers.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/base.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/grpc.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/rest.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/rest_base.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/app_connector_instance_config.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/app_connector_instance_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/app_connectors_service.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/app_connectors_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/resource_info.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/resource_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_create_app_connector_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_create_app_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_delete_app_connector_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_delete_app_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_get_app_connector_async.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_get_app_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_get_app_connector_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_get_app_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_list_app_connectors_async.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_list_app_connectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_list_app_connectors_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_list_app_connectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_report_status_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_report_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_update_app_connector_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_update_app_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/tests/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/tests/unit/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/tests/unit/gapic/beyondcorp_appconnectors_v1/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/tests/unit/gapic/beyondcorp_appconnectors_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/.flake8
+++ b/packages/google-cloud-beyondcorp-appgateways/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/MANIFEST.in
+++ b/packages/google-cloud-beyondcorp-appgateways/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/client.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/pagers.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/base.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/grpc.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/rest.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/rest_base.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/types/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/types/app_gateways_service.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/types/app_gateways_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_create_app_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_create_app_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_delete_app_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_delete_app_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_get_app_gateway_async.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_get_app_gateway_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_get_app_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_get_app_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_list_app_gateways_async.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_list_app_gateways_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_list_app_gateways_sync.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_list_app_gateways_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/tests/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/tests/unit/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/tests/unit/gapic/beyondcorp_appgateways_v1/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/tests/unit/gapic/beyondcorp_appgateways_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/.flake8
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/MANIFEST.in
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/client.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/pagers.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/base.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/grpc.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/rest.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/rest_base.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/types/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/types/client_connector_services_service.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/types/client_connector_services_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_create_client_connector_service_sync.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_create_client_connector_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_delete_client_connector_service_sync.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_delete_client_connector_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_get_client_connector_service_async.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_get_client_connector_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_get_client_connector_service_sync.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_get_client_connector_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_list_client_connector_services_async.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_list_client_connector_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_list_client_connector_services_sync.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_list_client_connector_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_update_client_connector_service_sync.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_update_client_connector_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/tests/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/gapic/beyondcorp_clientconnectorservices_v1/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/gapic/beyondcorp_clientconnectorservices_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/.flake8
+++ b/packages/google-cloud-beyondcorp-clientgateways/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/MANIFEST.in
+++ b/packages/google-cloud-beyondcorp-clientgateways/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/client.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/pagers.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/base.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/grpc.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/rest.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/rest_base.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/types/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/types/client_gateways_service.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/types/client_gateways_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_create_client_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_create_client_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_delete_client_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_delete_client_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_get_client_gateway_async.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_get_client_gateway_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_get_client_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_get_client_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_list_client_gateways_async.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_list_client_gateways_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_list_client_gateways_sync.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_list_client_gateways_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/tests/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/tests/unit/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/tests/unit/gapic/beyondcorp_clientgateways_v1/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/tests/unit/gapic/beyondcorp_clientgateways_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/.flake8
+++ b/packages/google-cloud-biglake-hive/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/MANIFEST.in
+++ b/packages/google-cloud-biglake-hive/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive/__init__.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive/gapic_version.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/gapic_version.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/__init__.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/__init__.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/async_client.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/client.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/pagers.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/__init__.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/base.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/grpc.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/rest.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/rest_base.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/types/__init__.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/types/hive_metastore.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/types/hive_metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_create_partitions_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_create_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_create_partitions_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_create_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_delete_partitions_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_delete_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_delete_partitions_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_delete_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_update_partitions_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_update_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_update_partitions_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_update_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_catalog_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_catalog_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_database_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_database_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_table_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_table_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_catalog_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_catalog_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_database_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_database_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_table_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_table_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_catalog_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_catalog_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_database_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_database_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_table_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_table_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_catalogs_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_catalogs_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_databases_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_databases_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_tables_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_tables_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_partitions_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_partitions_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_catalog_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_catalog_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_database_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_database_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_table_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_table_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/tests/__init__.py
+++ b/packages/google-cloud-biglake-hive/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/tests/unit/__init__.py
+++ b/packages/google-cloud-biglake-hive/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-biglake-hive/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/tests/unit/gapic/biglake_hive_v1beta/__init__.py
+++ b/packages/google-cloud-biglake-hive/tests/unit/gapic/biglake_hive_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/.flake8
+++ b/packages/google-cloud-biglake/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/MANIFEST.in
+++ b/packages/google-cloud-biglake/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake/gapic_version.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/gapic_version.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/async_client.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/client.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/pagers.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/base.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/grpc.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/rest.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/types/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/types/iceberg_rest_catalog.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/types/iceberg_rest_catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_create_iceberg_catalog_async.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_create_iceberg_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_create_iceberg_catalog_sync.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_create_iceberg_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_failover_iceberg_catalog_async.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_failover_iceberg_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_failover_iceberg_catalog_sync.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_failover_iceberg_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_get_iceberg_catalog_async.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_get_iceberg_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_get_iceberg_catalog_sync.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_get_iceberg_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_list_iceberg_catalogs_async.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_list_iceberg_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_list_iceberg_catalogs_sync.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_list_iceberg_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_update_iceberg_catalog_async.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_update_iceberg_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_update_iceberg_catalog_sync.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_update_iceberg_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/tests/__init__.py
+++ b/packages/google-cloud-biglake/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/tests/unit/__init__.py
+++ b/packages/google-cloud-biglake/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-biglake/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/tests/unit/gapic/biglake_v1/__init__.py
+++ b/packages/google-cloud-biglake/tests/unit/gapic/biglake_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/.flake8
+++ b/packages/google-cloud-bigquery-analyticshub/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/MANIFEST.in
+++ b/packages/google-cloud-bigquery-analyticshub/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub/gapic_version.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/client.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/pagers.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/base.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/analyticshub.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/analyticshub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/pubsub.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/pubsub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_approve_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_approve_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_approve_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_approve_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_listing_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_listing_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_listing_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_listing_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_subscription_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_listing_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_listing_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_subscription_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_subscription_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_data_exchanges_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_data_exchanges_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_data_exchanges_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_data_exchanges_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_listings_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_listings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_listings_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_listings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_org_data_exchanges_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_org_data_exchanges_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_org_data_exchanges_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_org_data_exchanges_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_query_templates_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_query_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_query_templates_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_query_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_shared_resource_subscriptions_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_shared_resource_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_shared_resource_subscriptions_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_shared_resource_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_subscriptions_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_subscriptions_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_refresh_subscription_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_refresh_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_revoke_subscription_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_revoke_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_revoke_subscription_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_revoke_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_submit_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_submit_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_submit_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_submit_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_listing_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_listing_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_listing_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_listing_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/tests/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/tests/unit/gapic/bigquery_analyticshub_v1/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/tests/unit/gapic/bigquery_analyticshub_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/.flake8
+++ b/packages/google-cloud-bigquery-biglake/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/MANIFEST.in
+++ b/packages/google-cloud-bigquery-biglake/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake/gapic_version.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/async_client.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/client.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/pagers.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/base.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/types/metastore.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/types/metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/async_client.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/client.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/pagers.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/base.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/types/metastore.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/types/metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_catalogs_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_catalogs_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_databases_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_databases_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_tables_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_tables_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_rename_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_rename_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_rename_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_rename_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_check_lock_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_check_lock_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_check_lock_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_check_lock_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_lock_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_lock_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_lock_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_lock_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_lock_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_lock_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_lock_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_lock_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_catalogs_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_catalogs_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_databases_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_databases_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_locks_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_locks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_locks_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_locks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_tables_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_tables_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_rename_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_rename_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_rename_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_rename_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/tests/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/tests/unit/gapic/bigquery_biglake_v1/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/tests/unit/gapic/bigquery_biglake_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/tests/unit/gapic/bigquery_biglake_v1alpha1/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/tests/unit/gapic/bigquery_biglake_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/.flake8
+++ b/packages/google-cloud-bigquery-connection/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/MANIFEST.in
+++ b/packages/google-cloud-bigquery-connection/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection/__init__.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection/gapic_version.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/__init__.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/async_client.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/client.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/pagers.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/base.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/types/connection.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/types/connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_create_connection_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_create_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_create_connection_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_create_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_delete_connection_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_delete_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_delete_connection_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_delete_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_connection_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_connection_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_list_connections_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_list_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_list_connections_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_list_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_update_connection_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_update_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_update_connection_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_update_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/tests/__init__.py
+++ b/packages/google-cloud-bigquery-connection/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-connection/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-connection/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/tests/unit/gapic/bigquery_connection_v1/__init__.py
+++ b/packages/google-cloud-bigquery-connection/tests/unit/gapic/bigquery_connection_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/.flake8
+++ b/packages/google-cloud-bigquery-data-exchange/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/MANIFEST.in
+++ b/packages/google-cloud-bigquery-data-exchange/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange/gapic_version.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/gapic_version.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/async_client.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/client.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/pagers.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/base.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/types/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/types/dataexchange.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/types/dataexchange.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_listing_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_listing_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_listing_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_listing_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_listing_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_listing_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_data_exchanges_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_data_exchanges_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_data_exchanges_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_data_exchanges_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_listings_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_listings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_listings_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_listings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_org_data_exchanges_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_org_data_exchanges_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_org_data_exchanges_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_org_data_exchanges_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_subscribe_listing_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_subscribe_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_subscribe_listing_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_subscribe_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_listing_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_listing_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/tests/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/tests/unit/gapic/bigquery_data_exchange_v1beta1/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/tests/unit/gapic/bigquery_data_exchange_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/.flake8
+++ b/packages/google-cloud-bigquery-datapolicies/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/MANIFEST.in
+++ b/packages/google-cloud-bigquery-datapolicies/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies/gapic_version.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/async_client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/pagers.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/types/datapolicy.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/types/datapolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/gapic_version.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/async_client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/pagers.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/types/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/types/datapolicy.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/types/datapolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/gapic_version.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/async_client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/pagers.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/types/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/types/datapolicy.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/types/datapolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/gapic_version.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/async_client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/pagers.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/types/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/types/datapolicy.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/types/datapolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_create_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_create_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_create_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_create_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_delete_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_delete_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_delete_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_delete_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_list_data_policies_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_list_data_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_list_data_policies_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_list_data_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_rename_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_rename_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_rename_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_rename_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_update_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_update_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_update_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_update_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_create_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_create_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_create_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_create_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_delete_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_delete_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_delete_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_delete_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_list_data_policies_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_list_data_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_list_data_policies_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_list_data_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_update_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_update_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_update_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_update_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_add_grantees_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_add_grantees_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_add_grantees_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_add_grantees_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_create_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_create_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_create_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_create_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_delete_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_delete_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_delete_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_delete_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_list_data_policies_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_list_data_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_list_data_policies_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_list_data_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_remove_grantees_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_remove_grantees_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_remove_grantees_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_remove_grantees_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_update_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_update_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_update_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_update_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_add_grantees_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_add_grantees_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_add_grantees_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_add_grantees_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_create_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_create_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_create_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_create_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_delete_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_delete_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_delete_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_delete_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_list_data_policies_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_list_data_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_list_data_policies_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_list_data_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_remove_grantees_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_remove_grantees_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_remove_grantees_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_remove_grantees_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_update_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_update_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_update_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_update_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v1/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v1beta1/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v2/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v2beta1/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v2beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/.flake8
+++ b/packages/google-cloud-bigquery-datatransfer/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/MANIFEST.in
+++ b/packages/google-cloud-bigquery-datatransfer/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer/gapic_version.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/async_client.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/client.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/pagers.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/base.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/datatransfer.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/datatransfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/transfer.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_check_valid_creds_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_check_valid_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_check_valid_creds_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_check_valid_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_create_transfer_config_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_create_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_create_transfer_config_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_create_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_config_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_config_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_run_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_run_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_enroll_data_sources_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_enroll_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_enroll_data_sources_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_enroll_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_data_source_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_data_source_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_config_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_config_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_run_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_run_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_data_sources_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_data_sources_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_configs_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_configs_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_logs_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_logs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_logs_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_logs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_runs_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_runs_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_schedule_transfer_runs_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_schedule_transfer_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_schedule_transfer_runs_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_schedule_transfer_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_start_manual_transfer_runs_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_start_manual_transfer_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_start_manual_transfer_runs_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_start_manual_transfer_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_unenroll_data_sources_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_unenroll_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_unenroll_data_sources_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_unenroll_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_update_transfer_config_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_update_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_update_transfer_config_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_update_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/tests/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/tests/unit/gapic/bigquery_datatransfer_v1/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/tests/unit/gapic/bigquery_datatransfer_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/.flake8
+++ b/packages/google-cloud-bigquery-logging/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/MANIFEST.in
+++ b/packages/google-cloud-bigquery-logging/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging/__init__.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging/gapic_version.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/types/audit_data.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/types/audit_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/tests/__init__.py
+++ b/packages/google-cloud-bigquery-logging/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-logging/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-logging/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/tests/unit/gapic/bigquery_logging_v1/__init__.py
+++ b/packages/google-cloud-bigquery-logging/tests/unit/gapic/bigquery_logging_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/.flake8
+++ b/packages/google-cloud-bigquery-migration/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/MANIFEST.in
+++ b/packages/google-cloud-bigquery-migration/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration/gapic_version.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/gapic_version.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/async_client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/pagers.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/base.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_entities.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_entities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_error_details.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_error_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_metrics.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_service.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_config.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_details.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_suggestion.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_suggestion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_usability.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_usability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/gapic_version.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/async_client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/pagers.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/base.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/async_client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/base.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/assessment_task.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/assessment_task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_entities.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_entities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_error_details.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_error_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_metrics.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_service.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/translation_service.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/translation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/translation_task.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/translation_task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_create_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_create_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_create_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_create_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_delete_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_delete_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_delete_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_delete_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_subtask_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_subtask_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_subtask_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_subtask_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_subtasks_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_subtasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_subtasks_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_subtasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_workflows_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_workflows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_workflows_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_workflows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_start_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_start_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_start_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_start_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_create_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_create_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_create_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_create_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_delete_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_delete_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_delete_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_delete_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_subtask_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_subtask_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_subtask_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_subtask_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_subtasks_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_subtasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_subtasks_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_subtasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_workflows_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_workflows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_workflows_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_workflows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_start_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_start_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_start_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_start_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_sql_translation_service_translate_query_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_sql_translation_service_translate_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_sql_translation_service_translate_query_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_sql_translation_service_translate_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/tests/__init__.py
+++ b/packages/google-cloud-bigquery-migration/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-migration/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-migration/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/tests/unit/gapic/bigquery_migration_v2/__init__.py
+++ b/packages/google-cloud-bigquery-migration/tests/unit/gapic/bigquery_migration_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/tests/unit/gapic/bigquery_migration_v2alpha/__init__.py
+++ b/packages/google-cloud-bigquery-migration/tests/unit/gapic/bigquery_migration_v2alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/.flake8
+++ b/packages/google-cloud-bigquery-reservation/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/MANIFEST.in
+++ b/packages/google-cloud-bigquery-reservation/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation/gapic_version.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/async_client.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/client.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/pagers.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/base.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/types/reservation.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/types/reservation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_assignment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_assignment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_capacity_commitment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_capacity_commitment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_capacity_commitment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_capacity_commitment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_group_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_group_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_assignment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_assignment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_capacity_commitment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_capacity_commitment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_capacity_commitment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_capacity_commitment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_group_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_group_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_failover_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_failover_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_failover_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_failover_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_bi_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_bi_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_bi_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_bi_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_capacity_commitment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_capacity_commitment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_capacity_commitment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_capacity_commitment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_group_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_group_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_assignments_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_assignments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_assignments_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_assignments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_capacity_commitments_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_capacity_commitments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_capacity_commitments_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_capacity_commitments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservation_groups_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservation_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservation_groups_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservation_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservations_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservations_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_merge_capacity_commitments_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_merge_capacity_commitments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_merge_capacity_commitments_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_merge_capacity_commitments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_move_assignment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_move_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_move_assignment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_move_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_all_assignments_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_all_assignments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_all_assignments_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_all_assignments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_assignments_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_assignments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_assignments_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_assignments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_split_capacity_commitment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_split_capacity_commitment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_split_capacity_commitment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_split_capacity_commitment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_assignment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_assignment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_bi_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_bi_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_bi_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_bi_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_capacity_commitment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_capacity_commitment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_capacity_commitment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_capacity_commitment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/tests/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/tests/unit/gapic/bigquery_reservation_v1/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/tests/unit/gapic/bigquery_reservation_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/.flake8
+++ b/packages/google-cloud-bigquery-storage/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/MANIFEST.in
+++ b/packages/google-cloud-bigquery-storage/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/annotations.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/annotations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/arrow.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/arrow.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/avro.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/avro.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/protobuf.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/protobuf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/storage.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/storage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/stream.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/stream.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/table.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/metastore_partition.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/metastore_partition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/partition.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/partition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/metastore_partition.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/metastore_partition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/partition.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/partition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/arrow.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/arrow.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/avro.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/avro.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/protobuf.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/protobuf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/storage.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/storage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/stream.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/stream.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/table.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_create_read_session_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_create_read_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_create_read_session_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_create_read_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_read_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_read_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_read_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_read_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_split_read_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_split_read_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_split_read_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_split_read_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_append_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_append_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_append_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_append_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_batch_commit_write_streams_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_batch_commit_write_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_batch_commit_write_streams_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_batch_commit_write_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_create_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_create_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_create_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_create_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_finalize_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_finalize_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_finalize_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_finalize_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_flush_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_flush_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_flush_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_flush_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_get_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_get_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_get_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_get_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_create_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_create_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_create_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_create_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_delete_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_delete_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_delete_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_delete_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_update_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_update_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_update_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_update_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_list_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_list_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_list_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_list_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_stream_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_stream_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_stream_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_stream_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_create_read_session_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_create_read_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_create_read_session_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_create_read_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_read_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_read_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_read_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_read_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_split_read_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_split_read_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_split_read_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_split_read_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_append_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_append_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_append_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_append_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_batch_commit_write_streams_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_batch_commit_write_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_batch_commit_write_streams_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_batch_commit_write_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_create_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_create_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_create_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_create_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_finalize_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_finalize_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_finalize_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_finalize_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_flush_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_flush_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_flush_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_flush_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_get_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_get_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_get_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_get_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_create_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_create_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_create_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_create_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_delete_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_delete_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_delete_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_delete_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_update_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_update_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_update_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_update_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_list_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_list_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_list_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_list_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_stream_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_stream_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_stream_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_stream_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1alpha/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1beta/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1beta2/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/.flake8
+++ b/packages/google-cloud-billing-budgets/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/MANIFEST.in
+++ b/packages/google-cloud-billing-budgets/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets/gapic_version.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/gapic_version.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/async_client.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/client.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/pagers.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/base.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/grpc.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/rest.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/rest_base.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/budget_model.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/budget_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/budget_service.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/budget_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/gapic_version.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/async_client.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/client.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/pagers.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/base.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/grpc.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/budget_model.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/budget_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/budget_service.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/budget_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_create_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_create_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_create_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_create_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_delete_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_delete_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_delete_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_delete_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_get_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_get_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_get_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_get_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_list_budgets_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_list_budgets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_list_budgets_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_list_budgets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_update_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_update_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_update_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_update_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_create_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_create_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_create_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_create_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_delete_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_delete_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_delete_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_delete_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_get_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_get_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_get_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_get_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_list_budgets_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_list_budgets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_list_budgets_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_list_budgets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_update_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_update_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_update_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_update_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/tests/__init__.py
+++ b/packages/google-cloud-billing-budgets/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/tests/unit/__init__.py
+++ b/packages/google-cloud-billing-budgets/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-billing-budgets/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/tests/unit/gapic/budgets_v1/__init__.py
+++ b/packages/google-cloud-billing-budgets/tests/unit/gapic/budgets_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/tests/unit/gapic/budgets_v1beta1/__init__.py
+++ b/packages/google-cloud-billing-budgets/tests/unit/gapic/budgets_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/.flake8
+++ b/packages/google-cloud-billing/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/MANIFEST.in
+++ b/packages/google-cloud-billing/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing/gapic_version.py
+++ b/packages/google-cloud-billing/google/cloud/billing/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/gapic_version.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/async_client.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/client.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/pagers.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/base.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/grpc.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/grpc_asyncio.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/rest.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/rest_base.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/async_client.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/client.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/pagers.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/base.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/grpc.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/grpc_asyncio.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/rest.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/rest_base.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/types/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/types/cloud_billing.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/types/cloud_billing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/types/cloud_catalog.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/types/cloud_catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_create_billing_account_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_create_billing_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_create_billing_account_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_create_billing_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_billing_account_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_billing_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_billing_account_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_billing_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_iam_policy_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_iam_policy_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_project_billing_info_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_project_billing_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_project_billing_info_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_project_billing_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_billing_accounts_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_billing_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_billing_accounts_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_billing_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_project_billing_info_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_project_billing_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_project_billing_info_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_project_billing_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_move_billing_account_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_move_billing_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_move_billing_account_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_move_billing_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_set_iam_policy_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_set_iam_policy_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_test_iam_permissions_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_test_iam_permissions_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_billing_account_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_billing_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_billing_account_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_billing_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_project_billing_info_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_project_billing_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_project_billing_info_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_project_billing_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_services_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_services_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_skus_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_skus_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/tests/__init__.py
+++ b/packages/google-cloud-billing/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/tests/unit/__init__.py
+++ b/packages/google-cloud-billing/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-billing/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/tests/unit/gapic/billing_v1/__init__.py
+++ b/packages/google-cloud-billing/tests/unit/gapic/billing_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/.flake8
+++ b/packages/google-cloud-binary-authorization/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/MANIFEST.in
+++ b/packages/google-cloud-binary-authorization/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization/gapic_version.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/gapic_version.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/async_client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/pagers.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/grpc.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/rest.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/rest_base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/async_client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/grpc.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/rest.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/rest_base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/async_client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/grpc.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/rest.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/rest_base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/resources.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/service.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/gapic_version.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/async_client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/pagers.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/grpc.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/rest.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/rest_base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/async_client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/grpc.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/rest.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/rest_base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/continuous_validation_logging.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/continuous_validation_logging.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/resources.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/service.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_create_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_create_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_create_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_create_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_delete_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_delete_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_delete_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_delete_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_list_attestors_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_list_attestors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_list_attestors_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_list_attestors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_system_policy_v1_get_system_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_system_policy_v1_get_system_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_system_policy_v1_get_system_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_system_policy_v1_get_system_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_validation_helper_v1_validate_attestation_occurrence_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_validation_helper_v1_validate_attestation_occurrence_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_validation_helper_v1_validate_attestation_occurrence_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_validation_helper_v1_validate_attestation_occurrence_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_create_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_create_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_create_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_create_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_delete_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_delete_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_delete_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_delete_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_list_attestors_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_list_attestors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_list_attestors_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_list_attestors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_system_policy_v1_beta1_get_system_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_system_policy_v1_beta1_get_system_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_system_policy_v1_beta1_get_system_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_system_policy_v1_beta1_get_system_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/tests/__init__.py
+++ b/packages/google-cloud-binary-authorization/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/tests/unit/__init__.py
+++ b/packages/google-cloud-binary-authorization/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-binary-authorization/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/tests/unit/gapic/binaryauthorization_v1/__init__.py
+++ b/packages/google-cloud-binary-authorization/tests/unit/gapic/binaryauthorization_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/tests/unit/gapic/binaryauthorization_v1beta1/__init__.py
+++ b/packages/google-cloud-binary-authorization/tests/unit/gapic/binaryauthorization_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/.flake8
+++ b/packages/google-cloud-build/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/MANIFEST.in
+++ b/packages/google-cloud-build/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild/gapic_version.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/gapic_version.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/client.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/pagers.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/base.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/grpc.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/grpc_asyncio.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/rest.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/rest_base.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/types/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/types/cloudbuild.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/types/cloudbuild.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/gapic_version.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/client.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/pagers.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/base.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/grpc.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/rest.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/rest_base.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/cloudbuild.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/cloudbuild.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/repositories.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/repositories.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_approve_build_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_approve_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_cancel_build_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_cancel_build_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_cancel_build_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_cancel_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_trigger_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_trigger_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_worker_pool_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_build_trigger_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_build_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_build_trigger_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_build_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_worker_pool_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_trigger_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_trigger_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_default_service_account_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_default_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_default_service_account_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_default_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_worker_pool_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_worker_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_worker_pool_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_build_triggers_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_build_triggers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_build_triggers_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_build_triggers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_builds_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_builds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_builds_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_builds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_worker_pools_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_worker_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_worker_pools_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_worker_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_receive_trigger_webhook_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_receive_trigger_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_receive_trigger_webhook_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_receive_trigger_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_retry_build_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_retry_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_run_build_trigger_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_run_build_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_build_trigger_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_build_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_build_trigger_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_build_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_worker_pool_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_batch_create_repositories_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_batch_create_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_create_connection_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_create_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_create_repository_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_delete_connection_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_delete_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_delete_repository_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_git_refs_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_git_refs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_git_refs_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_git_refs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_linkable_repositories_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_linkable_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_linkable_repositories_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_linkable_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_token_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_token_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_write_token_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_write_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_write_token_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_write_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_connection_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_connection_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_repository_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_repository_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_connections_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_connections_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_repositories_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_repositories_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_update_connection_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_update_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/tests/__init__.py
+++ b/packages/google-cloud-build/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/tests/unit/__init__.py
+++ b/packages/google-cloud-build/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-build/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/tests/unit/gapic/cloudbuild_v1/__init__.py
+++ b/packages/google-cloud-build/tests/unit/gapic/cloudbuild_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/tests/unit/gapic/cloudbuild_v2/__init__.py
+++ b/packages/google-cloud-build/tests/unit/gapic/cloudbuild_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/.flake8
+++ b/packages/google-cloud-capacityplanner/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/MANIFEST.in
+++ b/packages/google-cloud-capacityplanner/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner/__init__.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner/gapic_version.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/gapic_version.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/__init__.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/__init__.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/client.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/__init__.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/base.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/grpc.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/rest.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/rest_base.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/__init__.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/allocation.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/allocation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/future_reservation.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/future_reservation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/location.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/resource.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_forecasts_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_forecasts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_reservations_usage_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_reservations_usage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_usage_histories_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_usage_histories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_forecasts_async.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_forecasts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_forecasts_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_forecasts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_reservations_async.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_reservations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_reservations_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_reservations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_usage_histories_async.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_usage_histories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_usage_histories_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_usage_histories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/tests/__init__.py
+++ b/packages/google-cloud-capacityplanner/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/tests/unit/__init__.py
+++ b/packages/google-cloud-capacityplanner/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-capacityplanner/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/tests/unit/gapic/capacityplanner_v1beta/__init__.py
+++ b/packages/google-cloud-capacityplanner/tests/unit/gapic/capacityplanner_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/.flake8
+++ b/packages/google-cloud-certificate-manager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/MANIFEST.in
+++ b/packages/google-cloud-certificate-manager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager/__init__.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager/gapic_version.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/gapic_version.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/__init__.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/__init__.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/client.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/pagers.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/__init__.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/base.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/grpc.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/rest.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/rest_base.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/__init__.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/certificate_issuance_config.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/certificate_issuance_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/certificate_manager.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/certificate_manager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/trust_config.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/trust_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_issuance_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_issuance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_map_entry_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_map_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_map_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_dns_authorization_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_dns_authorization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_trust_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_trust_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_issuance_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_issuance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_map_entry_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_map_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_map_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_dns_authorization_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_dns_authorization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_trust_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_trust_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_issuance_config_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_issuance_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_issuance_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_issuance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_entry_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_entry_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_dns_authorization_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_dns_authorization_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_dns_authorization_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_dns_authorization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_trust_config_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_trust_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_trust_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_trust_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_issuance_configs_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_issuance_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_issuance_configs_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_issuance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_map_entries_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_map_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_map_entries_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_map_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_maps_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_maps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_maps_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_maps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificates_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificates_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_dns_authorizations_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_dns_authorizations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_dns_authorizations_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_dns_authorizations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_trust_configs_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_trust_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_trust_configs_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_trust_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_map_entry_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_map_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_map_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_dns_authorization_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_dns_authorization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_trust_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_trust_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/tests/__init__.py
+++ b/packages/google-cloud-certificate-manager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/tests/unit/__init__.py
+++ b/packages/google-cloud-certificate-manager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-certificate-manager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/tests/unit/gapic/certificate_manager_v1/__init__.py
+++ b/packages/google-cloud-certificate-manager/tests/unit/gapic/certificate_manager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/.flake8
+++ b/packages/google-cloud-ces/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/MANIFEST.in
+++ b/packages/google-cloud-ces/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces/gapic_version.py
+++ b/packages/google-cloud-ces/google/cloud/ces/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/gapic_version.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/pagers.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/agent.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_transfers.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_transfers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/app.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/app.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/app_version.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/app_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/auth.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/auth.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/bigquery_export.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/bigquery_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/changelog.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/changelog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/client_function.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/client_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/common.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/connector_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/connector_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/connector_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/connector_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/conversation.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/data_store.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/data_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/data_store_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/data_store_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/deployment.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/example.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/example.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/fakes.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/fakes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/file_search_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/file_search_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/google_search_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/google_search_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/guardrail.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/guardrail.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/mcp_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/mcp_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/mcp_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/mcp_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/omnichannel.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/omnichannel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/omnichannel_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/omnichannel_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/open_api_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/open_api_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/open_api_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/open_api_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/python_function.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/python_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/schema.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/search_suggestions.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/search_suggestions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/security_settings.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/security_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/session_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/session_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/system_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/system_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/tool_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/tool_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/toolset_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/toolset_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/widget_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/widget_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/widget_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/widget_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/gapic_version.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/pagers.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/pagers.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_transfers.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_transfers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/app.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/app.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/app_version.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/app_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/auth.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/auth.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/bigquery_export.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/bigquery_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/changelog.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/changelog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/client_function.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/client_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/common.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/connector_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/connector_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/connector_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/connector_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/conversation.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/data_store.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/data_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/data_store_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/data_store_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/deployment.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/evaluation.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/evaluation_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/evaluation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/example.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/example.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/fakes.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/fakes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/file_context.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/file_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/file_search_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/file_search_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/golden_run.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/golden_run.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/google_search_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/google_search_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/guardrail.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/guardrail.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mcp_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mcp_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mcp_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mcp_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mocks.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mocks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/omnichannel.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/omnichannel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/omnichannel_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/omnichannel_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/open_api_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/open_api_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/open_api_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/open_api_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/python_function.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/python_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/schema.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/search_suggestions.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/search_suggestions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/security_settings.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/security_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/session_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/session_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/system_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/system_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/tool_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/tool_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/toolset_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/toolset_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/widget_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/widget_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/widget_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/widget_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_batch_delete_conversations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_batch_delete_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_conversation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_conversation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_export_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_export_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_changelog_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_changelog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_changelog_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_changelog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_conversation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_conversation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_import_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_import_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_agents_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_agents_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_app_versions_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_app_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_app_versions_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_app_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_apps_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_apps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_apps_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_apps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_changelogs_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_changelogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_changelogs_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_changelogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_conversations_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_conversations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_deployments_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_deployments_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_examples_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_examples_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_guardrails_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_guardrails_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_guardrails_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_guardrails_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_tools_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_tools_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_toolsets_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_toolsets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_toolsets_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_toolsets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_restore_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_restore_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_app_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_app_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_bidi_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_bidi_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_bidi_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_bidi_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_stream_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_stream_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_stream_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_stream_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_execute_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_execute_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_execute_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_execute_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tool_schema_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tool_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tool_schema_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tool_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tools_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tools_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_widget_service_generate_chat_token_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_widget_service_generate_chat_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_widget_service_generate_chat_token_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_widget_service_generate_chat_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_batch_delete_conversations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_batch_delete_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_conversation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_conversation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_export_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_export_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_generate_app_resource_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_generate_app_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_changelog_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_changelog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_changelog_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_changelog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_conversation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_conversation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_security_settings_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_security_settings_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_import_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_import_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_agents_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_agents_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_app_versions_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_app_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_app_versions_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_app_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_apps_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_apps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_apps_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_apps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_changelogs_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_changelogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_changelogs_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_changelogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_conversations_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_conversations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_deployments_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_deployments_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_examples_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_examples_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_guardrails_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_guardrails_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_guardrails_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_guardrails_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_tools_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_tools_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_toolsets_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_toolsets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_toolsets_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_toolsets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_restore_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_restore_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_app_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_app_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_security_settings_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_security_settings_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_dataset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_dataset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_expectation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_expectation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_expectation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_expectation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_scheduled_evaluation_run_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_scheduled_evaluation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_scheduled_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_scheduled_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_dataset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_dataset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_expectation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_expectation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_expectation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_expectation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_result_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_result_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_scheduled_evaluation_run_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_scheduled_evaluation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_scheduled_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_scheduled_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_export_evaluations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_export_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_generate_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_generate_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_dataset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_dataset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_expectation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_expectation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_expectation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_expectation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_result_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_result_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_run_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_scheduled_evaluation_run_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_scheduled_evaluation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_scheduled_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_scheduled_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_import_evaluations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_import_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_datasets_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_datasets_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_expectations_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_expectations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_expectations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_expectations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_results_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_results_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_runs_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_runs_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluations_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_scheduled_evaluation_runs_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_scheduled_evaluation_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_scheduled_evaluation_runs_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_scheduled_evaluation_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_run_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_run_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_test_persona_voice_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_test_persona_voice_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_test_persona_voice_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_test_persona_voice_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_dataset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_dataset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_expectation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_expectation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_expectation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_expectation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_scheduled_evaluation_run_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_scheduled_evaluation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_scheduled_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_scheduled_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_upload_evaluation_audio_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_upload_evaluation_audio_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_upload_evaluation_audio_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_upload_evaluation_audio_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_bidi_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_bidi_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_bidi_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_bidi_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_stream_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_stream_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_stream_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_stream_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_execute_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_execute_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_execute_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_execute_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tool_schema_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tool_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tool_schema_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tool_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tools_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tools_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_widget_service_generate_chat_token_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_widget_service_generate_chat_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_widget_service_generate_chat_token_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_widget_service_generate_chat_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/tests/__init__.py
+++ b/packages/google-cloud-ces/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/tests/unit/__init__.py
+++ b/packages/google-cloud-ces/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-ces/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/tests/unit/gapic/ces_v1/__init__.py
+++ b/packages/google-cloud-ces/tests/unit/gapic/ces_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/tests/unit/gapic/ces_v1beta/__init__.py
+++ b/packages/google-cloud-ces/tests/unit/gapic/ces_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/.flake8
+++ b/packages/google-cloud-channel/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/MANIFEST.in
+++ b/packages/google-cloud-channel/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel/gapic_version.py
+++ b/packages/google-cloud-channel/google/cloud/channel/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/gapic_version.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/client.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/pagers.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/base.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/grpc.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/client.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/pagers.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/base.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/grpc.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/billing_accounts.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/billing_accounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/channel_partner_links.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/channel_partner_links.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/common.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/customers.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/customers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/entitlement_changes.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/entitlement_changes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/entitlements.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/entitlements.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/offers.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/offers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/operations.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/products.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/products.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/reports_service.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/reports_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/repricing.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/repricing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/service.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/subscriber_event.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/subscriber_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_fetch_report_results_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_fetch_report_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_fetch_report_results_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_fetch_report_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_list_reports_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_list_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_list_reports_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_list_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_run_report_job_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_run_report_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_activate_entitlement_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_activate_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_cancel_entitlement_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_cancel_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_offer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_offer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_parameters_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_renewal_settings_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_renewal_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_check_cloud_identity_accounts_exist_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_check_cloud_identity_accounts_exist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_check_cloud_identity_accounts_exist_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_check_cloud_identity_accounts_exist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_link_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_link_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_entitlement_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_channel_partner_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_channel_partner_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_channel_partner_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_channel_partner_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_link_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_link_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_entitlement_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_entitlement_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_entitlement_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_import_customer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_import_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_import_customer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_import_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_links_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_links_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_repricing_configs_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_repricing_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_repricing_configs_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_repricing_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customer_repricing_configs_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customer_repricing_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customer_repricing_configs_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customer_repricing_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customers_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customers_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlement_changes_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlement_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlement_changes_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlement_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlements_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlements_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_offers_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_offers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_offers_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_offers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_products_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_products_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_offers_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_offers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_offers_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_offers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_skus_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_skus_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_group_billable_skus_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_group_billable_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_group_billable_skus_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_group_billable_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_groups_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_groups_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_skus_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_skus_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_subscribers_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_subscribers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_subscribers_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_subscribers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_offers_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_offers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_offers_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_offers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_skus_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_skus_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_lookup_offer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_lookup_offer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_lookup_offer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_lookup_offer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_provision_cloud_identity_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_provision_cloud_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_query_eligible_billing_accounts_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_query_eligible_billing_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_query_eligible_billing_accounts_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_query_eligible_billing_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_register_subscriber_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_register_subscriber_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_register_subscriber_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_register_subscriber_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_start_paid_service_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_start_paid_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_suspend_entitlement_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_suspend_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_transfer_entitlements_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_transfer_entitlements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_transfer_entitlements_to_google_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_transfer_entitlements_to_google_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_unregister_subscriber_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_unregister_subscriber_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_unregister_subscriber_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_unregister_subscriber_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_link_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_link_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/tests/__init__.py
+++ b/packages/google-cloud-channel/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/tests/unit/__init__.py
+++ b/packages/google-cloud-channel/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-channel/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/tests/unit/gapic/channel_v1/__init__.py
+++ b/packages/google-cloud-channel/tests/unit/gapic/channel_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/.flake8
+++ b/packages/google-cloud-chronicle/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/MANIFEST.in
+++ b/packages/google-cloud-chronicle/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle/gapic_version.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/gapic_version.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/big_query_export.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/big_query_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/dashboard_chart.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/dashboard_chart.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/dashboard_query.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/dashboard_query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/data_access_control.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/data_access_control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/data_table.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/data_table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/entity.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/entity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/featured_content_metadata.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/featured_content_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/featured_content_native_dashboard.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/featured_content_native_dashboard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/instance.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/native_dashboard.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/native_dashboard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/reference_list.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/reference_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/rule.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_get_big_query_export_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_get_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_get_big_query_export_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_get_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_provision_big_query_export_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_provision_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_provision_big_query_export_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_provision_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_update_big_query_export_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_update_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_update_big_query_export_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_update_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_batch_get_dashboard_charts_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_batch_get_dashboard_charts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_batch_get_dashboard_charts_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_batch_get_dashboard_charts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_get_dashboard_chart_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_get_dashboard_chart_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_get_dashboard_chart_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_get_dashboard_chart_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_execute_dashboard_query_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_execute_dashboard_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_execute_dashboard_query_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_execute_dashboard_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_get_dashboard_query_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_get_dashboard_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_get_dashboard_query_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_get_dashboard_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_label_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_label_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_scope_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_scope_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_label_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_label_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_scope_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_scope_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_label_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_label_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_scope_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_scope_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_labels_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_labels_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_scopes_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_scopes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_scopes_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_scopes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_label_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_label_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_scope_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_scope_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_create_data_table_rows_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_create_data_table_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_create_data_table_rows_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_create_data_table_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_get_data_table_rows_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_get_data_table_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_get_data_table_rows_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_get_data_table_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_replace_data_table_rows_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_replace_data_table_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_replace_data_table_rows_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_replace_data_table_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_update_data_table_rows_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_update_data_table_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_update_data_table_rows_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_update_data_table_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_row_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_row_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_row_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_row_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_operation_errors_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_operation_errors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_operation_errors_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_operation_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_row_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_row_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_table_rows_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_table_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_table_rows_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_table_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_tables_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_tables_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_row_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_row_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_create_watchlist_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_create_watchlist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_create_watchlist_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_create_watchlist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_delete_watchlist_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_delete_watchlist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_delete_watchlist_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_delete_watchlist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_get_watchlist_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_get_watchlist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_get_watchlist_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_get_watchlist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_list_watchlists_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_list_watchlists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_list_watchlists_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_list_watchlists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_update_watchlist_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_update_watchlist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_update_watchlist_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_update_watchlist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_get_featured_content_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_get_featured_content_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_get_featured_content_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_get_featured_content_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_install_featured_content_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_install_featured_content_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_install_featured_content_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_install_featured_content_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_list_featured_content_native_dashboards_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_list_featured_content_native_dashboards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_list_featured_content_native_dashboards_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_list_featured_content_native_dashboards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_instance_service_get_instance_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_instance_service_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_instance_service_get_instance_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_instance_service_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_add_chart_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_add_chart_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_add_chart_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_add_chart_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_create_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_create_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_create_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_create_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_delete_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_delete_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_delete_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_delete_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_chart_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_chart_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_chart_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_chart_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_edit_chart_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_edit_chart_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_edit_chart_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_edit_chart_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_export_native_dashboards_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_export_native_dashboards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_export_native_dashboards_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_export_native_dashboards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_get_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_get_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_get_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_get_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_import_native_dashboards_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_import_native_dashboards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_import_native_dashboards_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_import_native_dashboards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_list_native_dashboards_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_list_native_dashboards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_list_native_dashboards_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_list_native_dashboards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_remove_chart_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_remove_chart_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_remove_chart_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_remove_chart_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_update_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_update_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_update_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_update_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_create_reference_list_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_create_reference_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_create_reference_list_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_create_reference_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_get_reference_list_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_get_reference_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_get_reference_list_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_get_reference_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_list_reference_lists_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_list_reference_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_list_reference_lists_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_list_reference_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_update_reference_list_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_update_reference_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_update_reference_list_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_update_reference_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_retrohunt_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_retrohunt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_rule_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_rule_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_delete_rule_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_delete_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_delete_rule_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_delete_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_retrohunt_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_retrohunt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_retrohunt_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_retrohunt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_deployment_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_deployment_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_retrohunts_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_retrohunts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_retrohunts_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_retrohunts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_deployments_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_deployments_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_revisions_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_revisions_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rules_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rules_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_deployment_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_deployment_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/tests/__init__.py
+++ b/packages/google-cloud-chronicle/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/tests/unit/__init__.py
+++ b/packages/google-cloud-chronicle/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/__init__.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/.flake8
+++ b/packages/google-cloud-cloudcontrolspartner/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/MANIFEST.in
+++ b/packages/google-cloud-cloudcontrolspartner/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner/gapic_version.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/gapic_version.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/async_client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/pagers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/grpc.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/rest.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/rest_base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/async_client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/pagers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/grpc.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/rest.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/rest_base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/access_approval_requests.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/access_approval_requests.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/completion_state.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/completion_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/core.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/customer_workloads.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/customer_workloads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/customers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/customers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/ekm_connections.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/ekm_connections.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/monitoring.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/monitoring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/partner_permissions.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/partner_permissions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/partners.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/partners.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/violations.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/violations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/gapic_version.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/async_client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/pagers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/grpc.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/rest.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/rest_base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/async_client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/pagers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/grpc.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/rest.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/rest_base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/access_approval_requests.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/access_approval_requests.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/completion_state.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/completion_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/core.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/customer_workloads.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/customer_workloads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/customers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/customers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/ekm_connections.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/ekm_connections.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/monitoring.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/monitoring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/partner_permissions.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/partner_permissions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/partners.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/partners.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/violations.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/violations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_create_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_create_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_create_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_create_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_delete_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_delete_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_delete_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_delete_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_ekm_connections_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_ekm_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_ekm_connections_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_ekm_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_permissions_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_permissions_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_workload_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_workload_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_access_approval_requests_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_access_approval_requests_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_access_approval_requests_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_access_approval_requests_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_customers_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_customers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_customers_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_customers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_workloads_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_workloads_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_update_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_update_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_update_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_update_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_get_violation_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_get_violation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_get_violation_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_get_violation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_list_violations_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_list_violations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_list_violations_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_list_violations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_create_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_create_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_create_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_create_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_delete_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_delete_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_delete_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_delete_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_ekm_connections_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_ekm_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_ekm_connections_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_ekm_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_permissions_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_permissions_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_workload_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_workload_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_access_approval_requests_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_access_approval_requests_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_access_approval_requests_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_access_approval_requests_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_customers_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_customers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_customers_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_customers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_workloads_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_workloads_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_update_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_update_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_update_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_update_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_get_violation_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_get_violation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_get_violation_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_get_violation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_list_violations_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_list_violations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_list_violations_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_list_violations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/tests/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/tests/unit/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/cloudcontrolspartner_v1/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/cloudcontrolspartner_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/cloudcontrolspartner_v1beta/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/cloudcontrolspartner_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/.flake8
+++ b/packages/google-cloud-cloudsecuritycompliance/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/MANIFEST.in
+++ b/packages/google-cloud-cloudsecuritycompliance/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance/gapic_version.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/gapic_version.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/pagers.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/grpc.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/rest.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/rest_base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/async_client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/grpc.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/rest.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/rest_base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/async_client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/pagers.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/grpc.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/rest.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/rest_base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/pagers.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/grpc.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/rest.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/rest_base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/async_client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/pagers.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/grpc.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/rest.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/rest_base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/audit.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/audit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/cm_enrollment_service.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/cm_enrollment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/common.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/config.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/deployment.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/monitoring.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/monitoring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_create_framework_audit_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_create_framework_audit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_generate_framework_audit_scope_report_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_generate_framework_audit_scope_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_generate_framework_audit_scope_report_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_generate_framework_audit_scope_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_get_framework_audit_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_get_framework_audit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_get_framework_audit_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_get_framework_audit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_list_framework_audits_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_list_framework_audits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_list_framework_audits_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_list_framework_audits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_calculate_effective_cm_enrollment_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_calculate_effective_cm_enrollment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_calculate_effective_cm_enrollment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_calculate_effective_cm_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_update_cm_enrollment_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_update_cm_enrollment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_update_cm_enrollment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_update_cm_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_cloud_control_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_cloud_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_cloud_control_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_cloud_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_framework_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_framework_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_framework_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_framework_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_cloud_control_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_cloud_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_cloud_control_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_cloud_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_framework_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_framework_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_framework_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_framework_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_cloud_control_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_cloud_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_cloud_control_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_cloud_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_framework_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_framework_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_framework_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_framework_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_cloud_controls_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_cloud_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_cloud_controls_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_cloud_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_frameworks_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_frameworks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_frameworks_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_frameworks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_cloud_control_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_cloud_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_cloud_control_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_cloud_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_framework_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_framework_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_framework_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_framework_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_create_framework_deployment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_create_framework_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_delete_framework_deployment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_delete_framework_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_cloud_control_deployment_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_cloud_control_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_cloud_control_deployment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_cloud_control_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_framework_deployment_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_framework_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_framework_deployment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_framework_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_cloud_control_deployments_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_cloud_control_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_cloud_control_deployments_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_cloud_control_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_framework_deployments_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_framework_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_framework_deployments_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_framework_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_aggregate_framework_compliance_report_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_aggregate_framework_compliance_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_aggregate_framework_compliance_report_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_aggregate_framework_compliance_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_fetch_framework_compliance_report_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_fetch_framework_compliance_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_fetch_framework_compliance_report_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_fetch_framework_compliance_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_control_compliance_summaries_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_control_compliance_summaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_control_compliance_summaries_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_control_compliance_summaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_finding_summaries_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_finding_summaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_finding_summaries_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_finding_summaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_framework_compliance_summaries_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_framework_compliance_summaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_framework_compliance_summaries_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_framework_compliance_summaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/tests/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/tests/unit/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/tests/unit/gapic/cloudsecuritycompliance_v1/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/tests/unit/gapic/cloudsecuritycompliance_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/.flake8
+++ b/packages/google-cloud-commerce-consumer-procurement/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/MANIFEST.in
+++ b/packages/google-cloud-commerce-consumer-procurement/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement/gapic_version.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/gapic_version.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/client.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/pagers.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/grpc.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/rest.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/rest_base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/async_client.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/client.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/pagers.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/grpc.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/rest.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/rest_base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/license_management_service.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/license_management_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/order.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/procurement_service.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/procurement_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/client.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/pagers.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/grpc.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/rest.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/rest_base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/order.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/procurement_service.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/procurement_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_cancel_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_cancel_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_get_order_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_get_order_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_get_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_get_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_list_orders_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_list_orders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_list_orders_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_list_orders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_modify_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_modify_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_place_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_place_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_assign_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_assign_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_assign_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_assign_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_enumerate_licensed_users_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_enumerate_licensed_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_enumerate_licensed_users_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_enumerate_licensed_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_get_license_pool_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_get_license_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_get_license_pool_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_get_license_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_unassign_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_unassign_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_unassign_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_unassign_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_update_license_pool_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_update_license_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_update_license_pool_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_update_license_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_get_order_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_get_order_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_get_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_get_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_list_orders_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_list_orders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_list_orders_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_list_orders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_place_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_place_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/tests/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/tests/unit/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/commerce_consumer_procurement_v1/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/commerce_consumer_procurement_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/commerce_consumer_procurement_v1alpha1/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/commerce_consumer_procurement_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/.flake8
+++ b/packages/google-cloud-common/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/MANIFEST.in
+++ b/packages/google-cloud-common/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/google/cloud/common/gapic_version.py
+++ b/packages/google-cloud-common/google/cloud/common/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/google/cloud/common/services/__init__.py
+++ b/packages/google-cloud-common/google/cloud/common/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/google/cloud/common/types/__init__.py
+++ b/packages/google-cloud-common/google/cloud/common/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/google/cloud/common/types/operation_metadata.py
+++ b/packages/google-cloud-common/google/cloud/common/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/tests/__init__.py
+++ b/packages/google-cloud-common/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/tests/unit/__init__.py
+++ b/packages/google-cloud-common/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-common/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/tests/unit/gapic/common/__init__.py
+++ b/packages/google-cloud-common/tests/unit/gapic/common/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/.flake8
+++ b/packages/google-cloud-compute-v1beta/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/MANIFEST.in
+++ b/packages/google-cloud-compute-v1beta/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/gapic_version.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_move_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_advice_calendar_mode_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_advice_calendar_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_add_signed_url_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_add_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_delete_signed_url_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_delete_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_list_usable_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_set_edge_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_set_edge_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_add_signed_url_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_add_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_delete_signed_url_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_delete_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_effective_security_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_effective_security_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_health_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_list_usable_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_edge_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_edge_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_settings_service_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_settings_service_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_settings_service_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_settings_service_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_bulk_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_bulk_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_bulk_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_create_snapshot_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_resize_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_start_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_start_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_stop_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_stop_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_stop_group_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_stop_group_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_update_kms_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_list_associations_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_list_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_move_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_set_target_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_set_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_cancel_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_move_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_set_target_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_set_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_wait_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_image_family_views_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_image_family_views_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_deprecate_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_deprecate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_from_family_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_from_family_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_cancel_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_abandon_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_abandon_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_apply_updates_to_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_apply_updates_to_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_configure_accelerator_topologies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_configure_accelerator_topologies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_create_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_get_available_accelerator_topologies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_get_available_accelerator_topologies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_errors_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_managed_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_managed_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_patch_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_patch_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_recreate_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_recreate_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resize_advanced_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resize_advanced_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resize_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resume_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resume_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_auto_healing_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_auto_healing_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_instance_template_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_instance_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_target_pools_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_target_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_start_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_start_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_stop_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_stop_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_suspend_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_suspend_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_update_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_update_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_add_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_add_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_list_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_remove_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_remove_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_set_named_ports_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_set_named_ports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_settings_service_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_settings_service_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_settings_service_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_settings_service_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_access_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_network_interface_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_attach_disk_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_attach_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_bulk_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_access_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_network_interface_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_detach_disk_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_detach_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_guest_attributes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_guest_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_partner_metadata_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_partner_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_screenshot_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_screenshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_serial_port_output_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_serial_port_output_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_shielded_instance_identity_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_shielded_instance_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_shielded_vm_identity_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_shielded_vm_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_list_referrers_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_list_referrers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_patch_partner_metadata_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_patch_partner_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_report_host_as_faulty_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_report_host_as_faulty_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_reset_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_reset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_resume_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_resume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_send_diagnostic_interrupt_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_send_diagnostic_interrupt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_deletion_protection_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_deletion_protection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_disk_auto_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_disk_auto_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_machine_resources_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_machine_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_machine_type_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_machine_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_metadata_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_min_cpu_platform_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_min_cpu_platform_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_name_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_name_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_scheduling_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_scheduling_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_service_account_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_shielded_instance_integrity_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_shielded_instance_integrity_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_shielded_vm_integrity_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_shielded_vm_integrity_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_tags_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_simulate_maintenance_event_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_simulate_maintenance_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_start_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_start_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_start_with_encryption_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_start_with_encryption_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_stop_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_stop_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_suspend_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_suspend_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_access_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_display_device_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_display_device_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_network_interface_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_shielded_instance_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_shielded_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_shielded_vm_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_shielded_vm_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_operational_status_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_operational_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_create_members_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_create_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_operational_status_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_operational_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_locations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_locations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_locations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_locations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_remote_locations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_remote_locations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_remote_locations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_remote_locations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_diagnostics_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_diagnostics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_macsec_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_macsec_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_license_codes_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_license_codes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_license_codes_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_license_codes_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_profiles_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_profiles_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_profiles_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_profiles_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_add_peering_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_add_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_cancel_request_remove_peering_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_cancel_request_remove_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_list_peering_routes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_list_peering_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_remove_peering_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_remove_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_request_remove_peering_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_request_remove_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_switch_to_custom_mode_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_switch_to_custom_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_update_peering_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_update_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_add_nodes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_add_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_delete_nodes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_delete_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_list_nodes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_set_node_template_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_set_node_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_simulate_maintenance_event_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_simulate_maintenance_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_add_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_copy_rules_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_copy_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_associations_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_preconfigured_expression_sets_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_preconfigured_expression_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_move_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_disable_xpn_host_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_disable_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_disable_xpn_resource_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_disable_xpn_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_enable_xpn_host_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_enable_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_enable_xpn_resource_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_enable_xpn_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_xpn_host_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_xpn_resources_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_xpn_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_list_xpn_hosts_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_list_xpn_hosts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_move_disk_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_move_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_move_instance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_move_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_cloud_armor_tier_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_cloud_armor_tier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_common_instance_metadata_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_common_instance_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_default_network_tier_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_default_network_tier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_managed_protection_tier_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_managed_protection_tier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_usage_export_bucket_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_usage_export_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_announce_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_announce_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_withdraw_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_withdraw_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_announce_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_announce_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_withdraw_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_withdraw_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_list_usable_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_health_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_list_usable_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_set_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_update_reservations_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_update_reservations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_get_health_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_settings_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_settings_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_settings_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_settings_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_bulk_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_create_snapshot_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_resize_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_start_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_start_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_stop_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_stop_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_stop_group_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_stop_group_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_update_kms_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_get_health_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_cancel_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_abandon_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_abandon_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_adopt_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_adopt_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_apply_updates_to_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_apply_updates_to_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_create_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_errors_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_managed_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_managed_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_patch_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_patch_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_recreate_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_recreate_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resize_advanced_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resize_advanced_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resize_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resume_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resume_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_auto_healing_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_auto_healing_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_instance_template_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_instance_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_target_pools_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_target_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_start_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_start_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_stop_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_stop_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_suspend_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_suspend_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_update_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_update_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_list_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_set_named_ports_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_set_named_ports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instances_bulk_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instances_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_mig_members_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_mig_members_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_mig_members_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_mig_members_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_add_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_add_traffic_classification_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_add_traffic_classification_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_traffic_classification_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_traffic_classification_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_patch_traffic_classification_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_patch_traffic_classification_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_remove_traffic_classification_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_remove_traffic_classification_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_wait_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshot_settings_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshot_settings_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshot_settings_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshot_settings_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_update_kms_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_list_available_features_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_list_available_features_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_invalidate_cache_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_invalidate_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_validate_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_validate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_zones_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_zones_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_regions_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_regions_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_regions_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_regions_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_get_version_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_version_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_report_faulty_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_report_faulty_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_resize_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_cancel_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_named_set_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_named_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_route_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_named_set_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_named_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_nat_ip_info_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_nat_ip_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_nat_mapping_info_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_nat_mapping_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_route_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_router_status_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_router_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_bgp_routes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_bgp_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_named_sets_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_named_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_route_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_route_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_named_set_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_named_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_route_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_preview_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_named_set_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_named_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_route_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_list_preconfigured_expression_sets_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_list_preconfigured_expression_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_settings_service_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_settings_service_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_settings_service_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_settings_service_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_update_kms_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_list_available_features_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_list_available_features_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_list_disks_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_list_disks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_expand_ip_cidr_range_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_expand_ip_cidr_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_list_usable_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_set_private_ip_google_access_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_set_private_ip_google_access_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_certificate_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_quic_override_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_quic_override_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_ssl_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_ssl_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_set_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_add_health_check_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_add_health_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_add_instance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_add_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_get_health_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_remove_health_check_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_remove_health_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_remove_instance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_remove_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_set_backup_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_set_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_set_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_backend_service_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_backend_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_certificate_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_proxy_header_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_proxy_header_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_ssl_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_ssl_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_set_backend_service_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_set_backend_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_set_proxy_header_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_set_proxy_header_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_invalidate_cache_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_invalidate_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_validate_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_validate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_get_status_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_get_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_wait_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zones_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zones_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zones_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zones_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/tests/__init__.py
+++ b/packages/google-cloud-compute-v1beta/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/tests/unit/__init__.py
+++ b/packages/google-cloud-compute-v1beta/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-compute-v1beta/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/tests/unit/gapic/compute_v1beta/__init__.py
+++ b/packages/google-cloud-compute-v1beta/tests/unit/gapic/compute_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/.flake8
+++ b/packages/google-cloud-compute/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/MANIFEST.in
+++ b/packages/google-cloud-compute/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute/gapic_version.py
+++ b/packages/google-cloud-compute/google/cloud/compute/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/gapic_version.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_move_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_advice_calendar_mode_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_advice_calendar_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_add_signed_url_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_add_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_delete_signed_url_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_delete_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_list_usable_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_set_edge_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_set_edge_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_add_signed_url_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_add_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_delete_signed_url_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_delete_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_effective_security_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_effective_security_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_health_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_list_usable_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_edge_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_edge_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_bulk_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_bulk_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_bulk_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_create_snapshot_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_resize_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_start_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_start_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_stop_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_stop_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_stop_group_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_stop_group_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_update_kms_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_list_associations_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_list_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_move_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_set_target_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_set_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_cancel_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_move_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_set_target_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_set_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_wait_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_image_family_views_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_image_family_views_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_deprecate_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_deprecate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_from_family_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_from_family_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_cancel_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_abandon_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_abandon_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_apply_updates_to_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_apply_updates_to_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_create_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_errors_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_managed_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_managed_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_patch_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_patch_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_recreate_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_recreate_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_resize_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_resume_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_resume_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_set_instance_template_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_set_instance_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_set_target_pools_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_set_target_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_start_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_start_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_stop_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_stop_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_suspend_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_suspend_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_update_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_update_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_add_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_add_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_list_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_remove_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_remove_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_set_named_ports_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_set_named_ports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_settings_service_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_settings_service_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_settings_service_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_settings_service_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_access_config_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_network_interface_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_attach_disk_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_attach_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_bulk_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_access_config_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_network_interface_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_detach_disk_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_detach_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_guest_attributes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_guest_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_screenshot_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_screenshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_serial_port_output_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_serial_port_output_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_shielded_instance_identity_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_shielded_instance_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_list_referrers_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_list_referrers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_report_host_as_faulty_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_report_host_as_faulty_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_reset_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_reset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_resume_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_resume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_send_diagnostic_interrupt_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_send_diagnostic_interrupt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_deletion_protection_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_deletion_protection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_disk_auto_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_disk_auto_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_machine_resources_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_machine_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_machine_type_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_machine_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_metadata_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_min_cpu_platform_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_min_cpu_platform_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_name_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_name_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_scheduling_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_scheduling_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_service_account_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_shielded_instance_integrity_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_shielded_instance_integrity_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_tags_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_simulate_maintenance_event_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_simulate_maintenance_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_start_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_start_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_start_with_encryption_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_start_with_encryption_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_stop_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_stop_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_suspend_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_suspend_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_access_config_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_display_device_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_display_device_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_network_interface_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_shielded_instance_config_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_shielded_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_operational_status_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_operational_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_create_members_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_create_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_operational_status_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_operational_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_locations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_locations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_locations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_locations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_remote_locations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_remote_locations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_remote_locations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_remote_locations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_diagnostics_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_diagnostics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_macsec_config_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_macsec_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_license_codes_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_license_codes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_license_codes_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_license_codes_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_profiles_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_profiles_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_profiles_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_profiles_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_add_peering_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_add_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_list_peering_routes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_list_peering_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_remove_peering_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_remove_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_request_remove_peering_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_request_remove_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_switch_to_custom_mode_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_switch_to_custom_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_update_peering_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_update_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_add_nodes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_add_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_delete_nodes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_delete_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_list_nodes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_set_node_template_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_set_node_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_simulate_maintenance_event_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_simulate_maintenance_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_add_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_copy_rules_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_copy_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_associations_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_preconfigured_expression_sets_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_preconfigured_expression_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_move_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_disable_xpn_host_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_disable_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_disable_xpn_resource_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_disable_xpn_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_enable_xpn_host_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_enable_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_enable_xpn_resource_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_enable_xpn_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_xpn_host_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_xpn_resources_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_xpn_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_list_xpn_hosts_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_list_xpn_hosts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_move_disk_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_move_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_move_instance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_move_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_cloud_armor_tier_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_cloud_armor_tier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_common_instance_metadata_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_common_instance_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_default_network_tier_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_default_network_tier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_usage_export_bucket_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_usage_export_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_announce_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_announce_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_withdraw_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_withdraw_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_announce_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_announce_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_withdraw_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_withdraw_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_list_usable_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_health_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_list_usable_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_set_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_get_health_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disk_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disk_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disk_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disk_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_bulk_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_create_snapshot_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_resize_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_start_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_start_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_stop_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_stop_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_stop_group_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_stop_group_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_update_kms_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_get_health_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_cancel_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_abandon_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_abandon_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_apply_updates_to_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_apply_updates_to_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_create_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_errors_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_managed_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_managed_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_patch_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_patch_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_recreate_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_recreate_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_resize_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_resume_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_resume_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_set_instance_template_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_set_instance_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_set_target_pools_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_set_target_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_start_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_start_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_stop_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_stop_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_suspend_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_suspend_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_update_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_update_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_list_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_set_named_ports_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_set_named_ports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instances_bulk_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instances_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_wait_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshot_settings_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshot_settings_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshot_settings_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshot_settings_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_update_kms_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_list_available_features_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_list_available_features_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_validate_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_validate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_zones_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_zones_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_regions_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_regions_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_regions_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_regions_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_get_version_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_version_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_report_faulty_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_report_faulty_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_resize_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_delete_route_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_delete_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_nat_ip_info_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_nat_ip_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_nat_mapping_info_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_nat_mapping_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_route_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_router_status_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_router_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_bgp_routes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_bgp_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_route_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_route_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_patch_route_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_patch_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_preview_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_update_route_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_update_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_list_preconfigured_expression_sets_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_list_preconfigured_expression_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshot_settings_service_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshot_settings_service_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshot_settings_service_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshot_settings_service_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_update_kms_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_list_available_features_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_list_available_features_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_list_disks_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_list_disks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_expand_ip_cidr_range_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_expand_ip_cidr_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_list_usable_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_set_private_ip_google_access_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_set_private_ip_google_access_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_certificate_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_quic_override_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_quic_override_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_ssl_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_ssl_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_set_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_add_health_check_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_add_health_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_add_instance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_add_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_get_health_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_remove_health_check_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_remove_health_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_remove_instance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_remove_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_set_backup_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_set_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_set_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_backend_service_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_backend_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_certificate_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_proxy_header_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_proxy_header_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_ssl_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_ssl_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_set_backend_service_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_set_backend_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_set_proxy_header_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_set_proxy_header_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_invalidate_cache_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_invalidate_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_validate_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_validate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_get_status_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_get_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_wait_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zones_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zones_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zones_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zones_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/tests/__init__.py
+++ b/packages/google-cloud-compute/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/tests/unit/__init__.py
+++ b/packages/google-cloud-compute/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-compute/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/tests/unit/gapic/compute_v1/__init__.py
+++ b/packages/google-cloud-compute/tests/unit/gapic/compute_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/.flake8
+++ b/packages/google-cloud-confidentialcomputing/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/MANIFEST.in
+++ b/packages/google-cloud-confidentialcomputing/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing/gapic_version.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/gapic_version.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/async_client.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/client.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/base.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/grpc.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/grpc_asyncio.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/rest.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/rest_base.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/types/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/types/service.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_create_challenge_async.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_create_challenge_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_create_challenge_sync.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_create_challenge_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_attestation_async.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_attestation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_attestation_sync.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_attestation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_gke_async.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_gke_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_gke_sync.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_gke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_space_async.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_space_sync.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/tests/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/tests/unit/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/tests/unit/gapic/confidentialcomputing_v1/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/tests/unit/gapic/confidentialcomputing_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/.flake8
+++ b/packages/google-cloud-config/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/MANIFEST.in
+++ b/packages/google-cloud-config/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config/__init__.py
+++ b/packages/google-cloud-config/google/cloud/config/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config/gapic_version.py
+++ b/packages/google-cloud-config/google/cloud/config/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/gapic_version.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/__init__.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/__init__.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/client.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/pagers.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/__init__.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/base.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/grpc.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/grpc_asyncio.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/rest.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/rest_base.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/types/__init__.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/types/config.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/types/config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_preview_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_preview_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_statefile_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_statefile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_statefile_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_statefile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_deprovision_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_deprovision_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_deployment_statefile_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_deployment_statefile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_deployment_statefile_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_deployment_statefile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_lock_info_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_lock_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_lock_info_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_lock_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_preview_result_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_preview_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_preview_result_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_preview_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_revision_statefile_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_revision_statefile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_revision_statefile_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_revision_statefile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_auto_migration_config_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_auto_migration_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_auto_migration_config_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_auto_migration_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_revision_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_revision_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_preview_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_preview_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_preview_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_change_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_change_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_change_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_change_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_drift_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_drift_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_drift_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_drift_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_revision_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_revision_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_terraform_version_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_terraform_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_terraform_version_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_terraform_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_import_statefile_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_import_statefile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_import_statefile_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_import_statefile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_group_revisions_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_group_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_group_revisions_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_group_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_groups_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_groups_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployments_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployments_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_previews_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_previews_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_previews_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_previews_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_changes_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_changes_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_drifts_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_drifts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_drifts_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_drifts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resources_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resources_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_revisions_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_revisions_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_terraform_versions_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_terraform_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_terraform_versions_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_terraform_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_lock_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_lock_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_provision_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_provision_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_unlock_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_unlock_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_auto_migration_config_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_auto_migration_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/tests/__init__.py
+++ b/packages/google-cloud-config/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/tests/unit/__init__.py
+++ b/packages/google-cloud-config/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-config/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/tests/unit/gapic/config_v1/__init__.py
+++ b/packages/google-cloud-config/tests/unit/gapic/config_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/.flake8
+++ b/packages/google-cloud-configdelivery/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/MANIFEST.in
+++ b/packages/google-cloud-configdelivery/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery/gapic_version.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/gapic_version.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/client.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/pagers.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/grpc.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/grpc_asyncio.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/rest.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/rest_base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/types/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/types/config_delivery.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/types/config_delivery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/gapic_version.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/client.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/pagers.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/grpc.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/grpc_asyncio.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/rest.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/rest_base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/types/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/types/config_delivery.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/types/config_delivery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/gapic_version.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/client.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/pagers.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/grpc.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/grpc_asyncio.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/rest.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/rest_base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/types/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/types/config_delivery.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/types/config_delivery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_abort_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_abort_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_fleet_package_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_fleet_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_release_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_resource_bundle_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_resource_bundle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_rollout_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_variant_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_variant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_fleet_packages_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_fleet_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_fleet_packages_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_fleet_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_releases_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_releases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_releases_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_releases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_resource_bundles_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_resource_bundles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_resource_bundles_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_resource_bundles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_rollouts_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_rollouts_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_variants_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_variants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_variants_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_variants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_resume_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_resume_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_suspend_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_suspend_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_abort_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_abort_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_fleet_package_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_fleet_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_release_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_resource_bundle_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_resource_bundle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_rollout_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_variant_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_variant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_fleet_packages_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_fleet_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_fleet_packages_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_fleet_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_releases_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_releases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_releases_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_releases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_resource_bundles_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_resource_bundles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_resource_bundles_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_resource_bundles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_rollouts_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_rollouts_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_variants_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_variants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_variants_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_variants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_resume_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_resume_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_suspend_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_suspend_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_abort_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_abort_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_fleet_package_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_fleet_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_release_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_resource_bundle_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_resource_bundle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_rollout_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_variant_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_variant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_fleet_packages_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_fleet_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_fleet_packages_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_fleet_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_releases_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_releases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_releases_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_releases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_resource_bundles_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_resource_bundles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_resource_bundles_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_resource_bundles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_rollouts_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_rollouts_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_variants_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_variants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_variants_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_variants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_resume_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_resume_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_suspend_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_suspend_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/unit/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1alpha/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1beta/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/.flake8
+++ b/packages/google-cloud-contact-center-insights/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/MANIFEST.in
+++ b/packages/google-cloud-contact-center-insights/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights/__init__.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights/gapic_version.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/gapic_version.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/__init__.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/__init__.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/client.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/pagers.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/__init__.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/base.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/grpc.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/rest.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/rest_base.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/__init__.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/contact_center_insights.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/contact_center_insights.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/resources.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_analyze_conversations_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_analyze_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_delete_conversations_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_delete_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_download_feedback_labels_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_download_feedback_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_upload_feedback_labels_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_upload_feedback_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_issue_model_stats_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_issue_model_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_issue_model_stats_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_issue_model_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_stats_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_stats_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_rule_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_rule_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_conversation_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_conversation_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_feedback_label_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_feedback_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_feedback_label_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_feedback_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_phrase_matcher_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_phrase_matcher_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_phrase_matcher_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_phrase_matcher_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_question_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_question_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_revision_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_view_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_view_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_rule_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_rule_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_conversation_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_conversation_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_feedback_label_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_feedback_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_feedback_label_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_feedback_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_phrase_matcher_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_phrase_matcher_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_phrase_matcher_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_phrase_matcher_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_question_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_question_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_revision_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_view_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_view_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_qa_scorecard_revision_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_qa_scorecard_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_export_insights_data_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_export_insights_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_export_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_export_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_rule_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_rule_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_conversation_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_conversation_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_encryption_spec_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_encryption_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_encryption_spec_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_encryption_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_feedback_label_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_feedback_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_feedback_label_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_feedback_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_model_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_phrase_matcher_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_phrase_matcher_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_phrase_matcher_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_phrase_matcher_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_question_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_question_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_revision_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_settings_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_settings_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_view_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_view_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_import_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_import_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_ingest_conversations_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_ingest_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_initialize_encryption_spec_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_initialize_encryption_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_all_feedback_labels_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_all_feedback_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_all_feedback_labels_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_all_feedback_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analyses_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analyses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analyses_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analyses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analysis_rules_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analysis_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analysis_rules_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analysis_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_conversations_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_conversations_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_feedback_labels_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_feedback_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_feedback_labels_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_feedback_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issue_models_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issue_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issue_models_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issue_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issues_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issues_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_phrase_matchers_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_phrase_matchers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_phrase_matchers_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_phrase_matchers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_questions_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_questions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_questions_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_questions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecard_revisions_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecard_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecard_revisions_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecard_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecards_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecards_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_views_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_views_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_views_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_views_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_query_metrics_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_query_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_tune_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_tune_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_qa_scorecard_revision_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_qa_scorecard_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_analysis_rule_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_analysis_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_analysis_rule_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_analysis_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_conversation_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_conversation_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_feedback_label_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_feedback_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_feedback_label_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_feedback_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_model_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_phrase_matcher_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_phrase_matcher_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_phrase_matcher_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_phrase_matcher_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_question_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_question_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_scorecard_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_scorecard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_scorecard_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_scorecard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_settings_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_settings_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_view_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_view_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_upload_conversation_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_upload_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/tests/__init__.py
+++ b/packages/google-cloud-contact-center-insights/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/tests/unit/__init__.py
+++ b/packages/google-cloud-contact-center-insights/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-contact-center-insights/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/tests/unit/gapic/contact_center_insights_v1/__init__.py
+++ b/packages/google-cloud-contact-center-insights/tests/unit/gapic/contact_center_insights_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/.flake8
+++ b/packages/google-cloud-container/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/MANIFEST.in
+++ b/packages/google-cloud-container/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container/gapic_version.py
+++ b/packages/google-cloud-container/google/cloud/container/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/gapic_version.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/async_client.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/client.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/pagers.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/base.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/grpc.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/rest.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/rest_base.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/types/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/types/cluster_service.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/types/cluster_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/gapic_version.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/async_client.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/client.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/pagers.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/base.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/grpc.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/types/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/types/cluster_service.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/types/cluster_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_cancel_operation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_cancel_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_cancel_operation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_cancel_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_check_autopilot_compatibility_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_check_autopilot_compatibility_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_check_autopilot_compatibility_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_check_autopilot_compatibility_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_ip_rotation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_ip_rotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_ip_rotation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_ip_rotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_node_pool_upgrade_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_node_pool_upgrade_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_node_pool_upgrade_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_node_pool_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_cluster_upgrade_info_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_cluster_upgrade_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_cluster_upgrade_info_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_cluster_upgrade_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_node_pool_upgrade_info_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_node_pool_upgrade_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_node_pool_upgrade_info_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_node_pool_upgrade_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_json_web_keys_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_json_web_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_json_web_keys_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_json_web_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_operation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_operation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_server_config_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_server_config_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_clusters_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_clusters_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_node_pools_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_node_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_node_pools_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_node_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_operations_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_operations_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_usable_subnetworks_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_usable_subnetworks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_usable_subnetworks_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_usable_subnetworks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_rollback_node_pool_upgrade_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_rollback_node_pool_upgrade_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_rollback_node_pool_upgrade_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_rollback_node_pool_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_addons_config_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_addons_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_addons_config_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_addons_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_labels_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_labels_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_legacy_abac_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_legacy_abac_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_legacy_abac_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_legacy_abac_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_locations_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_locations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_locations_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_locations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_logging_service_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_logging_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_logging_service_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_logging_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_maintenance_policy_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_maintenance_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_maintenance_policy_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_maintenance_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_master_auth_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_master_auth_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_master_auth_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_master_auth_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_monitoring_service_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_monitoring_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_monitoring_service_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_monitoring_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_network_policy_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_network_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_network_policy_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_autoscaling_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_autoscaling_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_autoscaling_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_autoscaling_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_management_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_management_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_management_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_management_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_size_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_size_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_size_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_size_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_start_ip_rotation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_start_ip_rotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_start_ip_rotation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_start_ip_rotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_master_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_master_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_master_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_master_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_cancel_operation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_cancel_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_cancel_operation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_cancel_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_check_autopilot_compatibility_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_check_autopilot_compatibility_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_check_autopilot_compatibility_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_check_autopilot_compatibility_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_control_plane_upgrade_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_control_plane_upgrade_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_control_plane_upgrade_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_control_plane_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_ip_rotation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_ip_rotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_ip_rotation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_ip_rotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_node_pool_upgrade_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_node_pool_upgrade_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_node_pool_upgrade_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_node_pool_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_cluster_upgrade_info_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_cluster_upgrade_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_cluster_upgrade_info_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_cluster_upgrade_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_node_pool_upgrade_info_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_node_pool_upgrade_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_node_pool_upgrade_info_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_node_pool_upgrade_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_json_web_keys_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_json_web_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_json_web_keys_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_json_web_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_operation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_operation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_server_config_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_server_config_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_clusters_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_clusters_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_locations_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_locations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_locations_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_locations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_node_pools_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_node_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_node_pools_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_node_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_operations_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_operations_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_usable_subnetworks_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_usable_subnetworks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_usable_subnetworks_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_usable_subnetworks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_rollback_node_pool_upgrade_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_rollback_node_pool_upgrade_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_rollback_node_pool_upgrade_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_rollback_node_pool_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_addons_config_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_addons_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_addons_config_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_addons_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_labels_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_labels_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_legacy_abac_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_legacy_abac_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_legacy_abac_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_legacy_abac_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_locations_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_locations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_locations_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_locations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_logging_service_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_logging_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_logging_service_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_logging_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_maintenance_policy_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_maintenance_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_maintenance_policy_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_maintenance_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_master_auth_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_master_auth_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_master_auth_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_master_auth_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_monitoring_service_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_monitoring_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_monitoring_service_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_monitoring_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_network_policy_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_network_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_network_policy_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_autoscaling_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_autoscaling_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_autoscaling_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_autoscaling_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_management_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_management_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_management_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_management_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_size_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_size_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_size_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_size_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_start_ip_rotation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_start_ip_rotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_start_ip_rotation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_start_ip_rotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_master_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_master_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_master_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_master_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/tests/__init__.py
+++ b/packages/google-cloud-container/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/tests/unit/__init__.py
+++ b/packages/google-cloud-container/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-container/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/tests/unit/gapic/container_v1/__init__.py
+++ b/packages/google-cloud-container/tests/unit/gapic/container_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/tests/unit/gapic/container_v1beta1/__init__.py
+++ b/packages/google-cloud-container/tests/unit/gapic/container_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/.flake8
+++ b/packages/google-cloud-containeranalysis/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/MANIFEST.in
+++ b/packages/google-cloud-containeranalysis/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis/__init__.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis/gapic_version.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/gapic_version.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/__init__.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/__init__.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/async_client.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/client.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/__init__.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/base.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/grpc.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/grpc_asyncio.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/rest.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/rest_base.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/__init__.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/containeranalysis.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/containeranalysis.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_export_sbom_async.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_export_sbom_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_export_sbom_sync.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_export_sbom_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_iam_policy_async.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_iam_policy_sync.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_vulnerability_occurrences_summary_async.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_vulnerability_occurrences_summary_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_vulnerability_occurrences_summary_sync.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_vulnerability_occurrences_summary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_set_iam_policy_async.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_set_iam_policy_sync.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_test_iam_permissions_async.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_test_iam_permissions_sync.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/tests/__init__.py
+++ b/packages/google-cloud-containeranalysis/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/tests/unit/__init__.py
+++ b/packages/google-cloud-containeranalysis/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-containeranalysis/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/tests/unit/gapic/containeranalysis_v1/__init__.py
+++ b/packages/google-cloud-containeranalysis/tests/unit/gapic/containeranalysis_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/.flake8
+++ b/packages/google-cloud-contentwarehouse/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/MANIFEST.in
+++ b/packages/google-cloud-contentwarehouse/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse/gapic_version.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/gapic_version.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/async_client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/pagers.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/async_client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/pagers.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/async_client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/pagers.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/async_client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/pagers.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/async_client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/pagers.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/async_document_service_request.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/async_document_service_request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/common.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_link_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_link_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_schema.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_schema_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_schema_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_service_request.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_service_request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/filters.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/filters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/histogram.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/histogram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/pipeline_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/pipeline_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/pipelines.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/pipelines.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/rule_engine.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/rule_engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/ruleset_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/ruleset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/ruleset_service_request.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/ruleset_service_request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset_service_request.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset_service_request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_create_document_link_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_create_document_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_create_document_link_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_create_document_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_delete_document_link_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_delete_document_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_delete_document_link_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_delete_document_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_sources_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_sources_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_targets_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_targets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_targets_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_targets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_create_document_schema_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_create_document_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_create_document_schema_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_create_document_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_delete_document_schema_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_delete_document_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_delete_document_schema_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_delete_document_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_get_document_schema_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_get_document_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_get_document_schema_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_get_document_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_list_document_schemas_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_list_document_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_list_document_schemas_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_list_document_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_update_document_schema_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_update_document_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_update_document_schema_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_update_document_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_create_document_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_create_document_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_delete_document_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_delete_document_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_fetch_acl_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_fetch_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_fetch_acl_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_fetch_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_get_document_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_get_document_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_lock_document_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_lock_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_lock_document_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_lock_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_search_documents_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_search_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_search_documents_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_search_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_set_acl_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_set_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_set_acl_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_set_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_update_document_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_update_document_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_pipeline_service_run_pipeline_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_pipeline_service_run_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_create_rule_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_create_rule_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_create_rule_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_create_rule_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_delete_rule_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_delete_rule_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_delete_rule_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_delete_rule_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_get_rule_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_get_rule_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_get_rule_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_get_rule_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_list_rule_sets_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_list_rule_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_list_rule_sets_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_list_rule_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_update_rule_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_update_rule_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_update_rule_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_update_rule_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_create_synonym_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_create_synonym_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_create_synonym_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_create_synonym_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_delete_synonym_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_delete_synonym_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_delete_synonym_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_delete_synonym_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_get_synonym_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_get_synonym_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_get_synonym_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_get_synonym_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_list_synonym_sets_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_list_synonym_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_list_synonym_sets_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_list_synonym_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_update_synonym_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_update_synonym_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_update_synonym_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_update_synonym_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/tests/__init__.py
+++ b/packages/google-cloud-contentwarehouse/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/tests/unit/__init__.py
+++ b/packages/google-cloud-contentwarehouse/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-contentwarehouse/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/tests/unit/gapic/contentwarehouse_v1/__init__.py
+++ b/packages/google-cloud-contentwarehouse/tests/unit/gapic/contentwarehouse_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/.flake8
+++ b/packages/google-cloud-data-fusion/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/MANIFEST.in
+++ b/packages/google-cloud-data-fusion/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion/__init__.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion/gapic_version.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/gapic_version.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/__init__.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/__init__.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/client.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/pagers.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/__init__.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/base.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/grpc.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/grpc_asyncio.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/rest.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/rest_base.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/types/__init__.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/types/datafusion.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/types/datafusion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_create_instance_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_delete_instance_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_get_instance_async.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_get_instance_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_available_versions_async.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_available_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_available_versions_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_available_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_instances_async.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_instances_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_restart_instance_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_restart_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_update_instance_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/tests/__init__.py
+++ b/packages/google-cloud-data-fusion/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/tests/unit/__init__.py
+++ b/packages/google-cloud-data-fusion/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-data-fusion/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/tests/unit/gapic/data_fusion_v1/__init__.py
+++ b/packages/google-cloud-data-fusion/tests/unit/gapic/data_fusion_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/.flake8
+++ b/packages/google-cloud-data-qna/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/MANIFEST.in
+++ b/packages/google-cloud-data-qna/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna/gapic_version.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/gapic_version.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/async_client.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/client.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/base.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/grpc.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/rest.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/rest_base.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/async_client.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/client.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/base.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/grpc.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/rest.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/rest_base.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/annotated_string.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/annotated_string.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/auto_suggestion_service.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/auto_suggestion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/question.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/question.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/question_service.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/question_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/user_feedback.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/user_feedback.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_auto_suggestion_service_suggest_queries_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_auto_suggestion_service_suggest_queries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_auto_suggestion_service_suggest_queries_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_auto_suggestion_service_suggest_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_create_question_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_create_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_create_question_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_create_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_execute_question_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_execute_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_execute_question_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_execute_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_question_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_question_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_user_feedback_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_user_feedback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_user_feedback_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_user_feedback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_update_user_feedback_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_update_user_feedback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_update_user_feedback_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_update_user_feedback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/tests/__init__.py
+++ b/packages/google-cloud-data-qna/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/tests/unit/__init__.py
+++ b/packages/google-cloud-data-qna/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-data-qna/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/tests/unit/gapic/dataqna_v1alpha/__init__.py
+++ b/packages/google-cloud-data-qna/tests/unit/gapic/dataqna_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/.flake8
+++ b/packages/google-cloud-databasecenter/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/MANIFEST.in
+++ b/packages/google-cloud-databasecenter/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter/__init__.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter/gapic_version.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/gapic_version.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/__init__.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/__init__.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/async_client.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/client.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/pagers.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/__init__.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/base.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/grpc.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/rest.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/rest_base.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/__init__.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/affiliation.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/affiliation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/machine_config.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/machine_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/maintenance.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/maintenance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/metric_data.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/metric_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/operation_error_type.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/operation_error_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/product.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/service.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/signals.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/suspension_reason.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/suspension_reason.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_fleet_async.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_fleet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_fleet_sync.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_fleet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_issue_stats_async.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_issue_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_issue_stats_sync.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_issue_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_database_resource_groups_async.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_database_resource_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_database_resource_groups_sync.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_database_resource_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_issues_async.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_issues_sync.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_products_async.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_products_sync.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/tests/__init__.py
+++ b/packages/google-cloud-databasecenter/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/tests/unit/__init__.py
+++ b/packages/google-cloud-databasecenter/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-databasecenter/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/tests/unit/gapic/databasecenter_v1beta/__init__.py
+++ b/packages/google-cloud-databasecenter/tests/unit/gapic/databasecenter_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/.flake8
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/MANIFEST.in
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement/gapic_version.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/gapic_version.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/async_client.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/client.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/base.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/grpc.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/rest.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/rest_base.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/types/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/types/configmanagement.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/types/configmanagement.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_get_config_async.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_get_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_get_config_sync.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_get_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_update_config_async.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_update_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_update_config_sync.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_update_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/tests/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/gapic/datacatalog_lineage_configmanagement_v1/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/gapic/datacatalog_lineage_configmanagement_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/.flake8
+++ b/packages/google-cloud-datacatalog/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/MANIFEST.in
+++ b/packages/google-cloud-datacatalog/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog/gapic_version.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/gapic_version.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/pagers.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/async_client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/pagers.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/async_client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/bigquery.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/bigquery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/common.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/data_source.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/data_source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/datacatalog.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/datacatalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/dataplex_spec.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/dataplex_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/dump_content.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/dump_content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/gcs_fileset_spec.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/gcs_fileset_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/physical_schema.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/physical_schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/policytagmanager.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/policytagmanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/policytagmanagerserialization.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/policytagmanagerserialization.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/schema.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/search.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/table_spec.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/table_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/tags.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/tags.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/timestamps.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/timestamps.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/usage.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/usage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/gapic_version.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/async_client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/pagers.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/async_client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/pagers.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/async_client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/common.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/datacatalog.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/datacatalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/gcs_fileset_spec.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/gcs_fileset_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/policytagmanager.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/policytagmanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/policytagmanagerserialization.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/policytagmanagerserialization.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/schema.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/search.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/table_spec.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/table_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/tags.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/tags.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/timestamps.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/timestamps.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_import_entries_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_import_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entries_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entries_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entry_groups_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entry_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entry_groups_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entry_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_tags_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_tags_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_lookup_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_lookup_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_lookup_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_lookup_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_contacts_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_contacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_contacts_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_overview_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_overview_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_overview_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_overview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_reconcile_tags_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_reconcile_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_enum_value_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_enum_value_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_enum_value_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_enum_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_config_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_config_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_effective_config_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_effective_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_effective_config_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_effective_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_search_catalog_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_search_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_search_catalog_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_search_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_config_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_config_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_star_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_star_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_star_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_star_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_test_iam_permissions_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_test_iam_permissions_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_unstar_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_unstar_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_unstar_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_unstar_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_policy_tags_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_policy_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_policy_tags_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_policy_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_export_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_export_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_export_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_export_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_import_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_import_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_import_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_import_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_replace_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_replace_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_replace_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_replace_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_set_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_set_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_test_iam_permissions_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_test_iam_permissions_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entries_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entries_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entry_groups_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entry_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entry_groups_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entry_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_tags_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_tags_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_lookup_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_lookup_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_lookup_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_lookup_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_enum_value_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_enum_value_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_enum_value_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_enum_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_search_catalog_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_search_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_search_catalog_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_search_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_set_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_set_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_test_iam_permissions_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_test_iam_permissions_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_policy_tags_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_policy_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_policy_tags_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_policy_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_export_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_export_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_export_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_export_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_import_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_import_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_import_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_import_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_set_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_set_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_test_iam_permissions_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_test_iam_permissions_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/tests/__init__.py
+++ b/packages/google-cloud-datacatalog/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/tests/unit/__init__.py
+++ b/packages/google-cloud-datacatalog/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-datacatalog/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/tests/unit/gapic/datacatalog_v1/__init__.py
+++ b/packages/google-cloud-datacatalog/tests/unit/gapic/datacatalog_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/tests/unit/gapic/datacatalog_v1beta1/__init__.py
+++ b/packages/google-cloud-datacatalog/tests/unit/gapic/datacatalog_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/.flake8
+++ b/packages/google-cloud-dataflow-client/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/MANIFEST.in
+++ b/packages/google-cloud-dataflow-client/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow/gapic_version.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/gapic_version.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/pagers.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/pagers.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/pagers.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/environment.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/environment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/jobs.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/jobs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/messages.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/metrics.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/snapshots.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/snapshots.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/streaming.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/streaming.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/templates.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/templates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_flex_templates_service_launch_flex_template_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_flex_templates_service_launch_flex_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_flex_templates_service_launch_flex_template_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_flex_templates_service_launch_flex_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_aggregated_list_jobs_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_aggregated_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_aggregated_list_jobs_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_aggregated_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_check_active_jobs_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_check_active_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_check_active_jobs_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_check_active_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_create_job_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_create_job_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_get_job_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_get_job_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_list_jobs_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_list_jobs_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_snapshot_job_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_snapshot_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_snapshot_job_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_snapshot_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_update_job_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_update_job_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_messages_v1_beta3_list_job_messages_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_messages_v1_beta3_list_job_messages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_messages_v1_beta3_list_job_messages_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_messages_v1_beta3_list_job_messages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_execution_details_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_execution_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_execution_details_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_execution_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_metrics_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_metrics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_metrics_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_stage_execution_details_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_stage_execution_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_stage_execution_details_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_stage_execution_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_delete_snapshot_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_delete_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_delete_snapshot_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_delete_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_get_snapshot_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_get_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_get_snapshot_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_get_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_list_snapshots_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_list_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_list_snapshots_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_list_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_create_job_from_template_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_create_job_from_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_create_job_from_template_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_create_job_from_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_get_template_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_get_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_get_template_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_get_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_launch_template_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_launch_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_launch_template_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_launch_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/tests/__init__.py
+++ b/packages/google-cloud-dataflow-client/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/tests/unit/__init__.py
+++ b/packages/google-cloud-dataflow-client/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dataflow-client/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/tests/unit/gapic/dataflow_v1beta3/__init__.py
+++ b/packages/google-cloud-dataflow-client/tests/unit/gapic/dataflow_v1beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/.flake8
+++ b/packages/google-cloud-dataform/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/MANIFEST.in
+++ b/packages/google-cloud-dataform/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform/gapic_version.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/gapic_version.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/client.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/pagers.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/base.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/grpc.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/rest.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/rest_base.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/types/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/types/dataform.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/types/dataform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/gapic_version.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/client.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/pagers.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/base.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/grpc.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/rest.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/rest_base.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/types/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/types/dataform.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/types/dataform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_cancel_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_cancel_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_cancel_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_cancel_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_repository_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_repository_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_repository_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_repository_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_workspace_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_workspace_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_workspace_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_workspace_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_compute_repository_access_token_status_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_compute_repository_access_token_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_compute_repository_access_token_status_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_compute_repository_access_token_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_compilation_result_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_compilation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_compilation_result_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_compilation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_tree_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_tree_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_tree_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_tree_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_diff_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_diff_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_diff_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_diff_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_git_statuses_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_git_statuses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_git_statuses_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_git_statuses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_git_ahead_behind_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_git_ahead_behind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_git_ahead_behind_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_git_ahead_behind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_remote_branches_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_remote_branches_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_remote_branches_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_remote_branches_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_repository_history_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_repository_history_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_repository_history_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_repository_history_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_compilation_result_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_compilation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_compilation_result_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_compilation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_iam_policy_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_iam_policy_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_install_npm_packages_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_install_npm_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_install_npm_packages_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_install_npm_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_compilation_results_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_compilation_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_compilation_results_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_compilation_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_release_configs_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_release_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_release_configs_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_release_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_repositories_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_repositories_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_configs_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_configs_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_invocations_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_invocations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_invocations_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_invocations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workspaces_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workspaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workspaces_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workspaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_make_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_make_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_make_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_make_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_pull_git_commits_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_pull_git_commits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_pull_git_commits_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_pull_git_commits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_push_git_commits_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_push_git_commits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_push_git_commits_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_push_git_commits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_compilation_result_actions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_compilation_result_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_compilation_result_actions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_compilation_result_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_directory_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_directory_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_directory_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_directory_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_folder_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_folder_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_folder_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_folder_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_repository_directory_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_repository_directory_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_repository_directory_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_repository_directory_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_team_folder_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_team_folder_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_team_folder_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_team_folder_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_user_root_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_user_root_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_user_root_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_user_root_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_workflow_invocation_actions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_workflow_invocation_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_workflow_invocation_actions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_workflow_invocation_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_repository_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_repository_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_repository_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_repository_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_reset_workspace_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_reset_workspace_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_reset_workspace_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_reset_workspace_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_files_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_files_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_team_folders_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_team_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_team_folders_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_team_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_set_iam_policy_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_set_iam_policy_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_test_iam_permissions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_test_iam_permissions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_write_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_write_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_write_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_write_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_cancel_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_cancel_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_cancel_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_cancel_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_repository_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_repository_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_repository_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_repository_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_workspace_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_workspace_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_workspace_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_workspace_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_compute_repository_access_token_status_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_compute_repository_access_token_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_compute_repository_access_token_status_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_compute_repository_access_token_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_compilation_result_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_compilation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_compilation_result_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_compilation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_diff_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_diff_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_diff_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_diff_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_git_statuses_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_git_statuses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_git_statuses_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_git_statuses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_git_ahead_behind_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_git_ahead_behind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_git_ahead_behind_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_git_ahead_behind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_remote_branches_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_remote_branches_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_remote_branches_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_remote_branches_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_repository_history_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_repository_history_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_repository_history_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_repository_history_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_compilation_result_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_compilation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_compilation_result_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_compilation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_iam_policy_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_iam_policy_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_install_npm_packages_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_install_npm_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_install_npm_packages_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_install_npm_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_compilation_results_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_compilation_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_compilation_results_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_compilation_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_release_configs_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_release_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_release_configs_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_release_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_repositories_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_repositories_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_configs_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_configs_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_invocations_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_invocations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_invocations_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_invocations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workspaces_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workspaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workspaces_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workspaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_make_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_make_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_make_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_make_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_pull_git_commits_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_pull_git_commits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_pull_git_commits_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_pull_git_commits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_push_git_commits_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_push_git_commits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_push_git_commits_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_push_git_commits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_compilation_result_actions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_compilation_result_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_compilation_result_actions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_compilation_result_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_directory_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_directory_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_directory_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_directory_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_folder_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_folder_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_folder_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_folder_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_repository_directory_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_repository_directory_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_repository_directory_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_repository_directory_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_team_folder_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_team_folder_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_team_folder_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_team_folder_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_user_root_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_user_root_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_user_root_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_user_root_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_workflow_invocation_actions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_workflow_invocation_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_workflow_invocation_actions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_workflow_invocation_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_repository_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_repository_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_repository_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_repository_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_reset_workspace_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_reset_workspace_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_reset_workspace_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_reset_workspace_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_files_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_files_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_team_folders_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_team_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_team_folders_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_team_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_set_iam_policy_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_set_iam_policy_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_test_iam_permissions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_test_iam_permissions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_write_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_write_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_write_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_write_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/tests/__init__.py
+++ b/packages/google-cloud-dataform/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/tests/unit/__init__.py
+++ b/packages/google-cloud-dataform/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dataform/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/tests/unit/gapic/dataform_v1/__init__.py
+++ b/packages/google-cloud-dataform/tests/unit/gapic/dataform_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/tests/unit/gapic/dataform_v1beta1/__init__.py
+++ b/packages/google-cloud-dataform/tests/unit/gapic/dataform_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/.flake8
+++ b/packages/google-cloud-datalabeling/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/MANIFEST.in
+++ b/packages/google-cloud-datalabeling/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling/__init__.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling/gapic_version.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/gapic_version.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/__init__.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/__init__.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/client.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/pagers.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/__init__.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/base.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/grpc.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/__init__.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/annotation.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/annotation_spec_set.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/annotation_spec_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/data_labeling_service.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/data_labeling_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/data_payloads.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/data_payloads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/dataset.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/evaluation.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/evaluation_job.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/evaluation_job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/human_annotation_config.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/human_annotation_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/instruction.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/instruction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/operations.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_annotation_spec_set_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_annotation_spec_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_annotation_spec_set_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_annotation_spec_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_dataset_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_dataset_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_instruction_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_instruction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotated_dataset_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotated_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotated_dataset_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotated_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotation_spec_set_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotation_spec_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotation_spec_set_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotation_spec_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_dataset_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_dataset_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_instruction_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_instruction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_instruction_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_instruction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_export_data_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotated_dataset_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotated_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotated_dataset_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotated_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotation_spec_set_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotation_spec_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotation_spec_set_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotation_spec_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_data_item_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_data_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_data_item_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_data_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_dataset_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_dataset_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_example_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_example_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_instruction_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_instruction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_instruction_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_instruction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_import_data_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_image_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_text_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_video_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotated_datasets_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotated_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotated_datasets_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotated_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotation_spec_sets_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotation_spec_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotation_spec_sets_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotation_spec_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_data_items_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_data_items_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_data_items_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_data_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_datasets_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_datasets_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_evaluation_jobs_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_evaluation_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_evaluation_jobs_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_evaluation_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_examples_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_examples_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_instructions_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_instructions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_instructions_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_instructions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_pause_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_pause_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_pause_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_pause_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_resume_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_resume_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_resume_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_resume_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_evaluations_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_evaluations_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_example_comparisons_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_example_comparisons_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_example_comparisons_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_example_comparisons_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_update_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_update_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_update_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_update_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/tests/__init__.py
+++ b/packages/google-cloud-datalabeling/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/tests/unit/__init__.py
+++ b/packages/google-cloud-datalabeling/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-datalabeling/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/tests/unit/gapic/datalabeling_v1beta1/__init__.py
+++ b/packages/google-cloud-datalabeling/tests/unit/gapic/datalabeling_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/.flake8
+++ b/packages/google-cloud-dataplex/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/MANIFEST.in
+++ b/packages/google-cloud-dataplex/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex/gapic_version.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/gapic_version.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/async_client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/async_client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/analyze.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/analyze.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/catalog.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/cmek.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/cmek.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/content.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_discovery.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_discovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_documentation.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_documentation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_products.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_products.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_profile.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_quality.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_quality.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_taxonomy.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_taxonomy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/datascans.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/datascans.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/datascans_common.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/datascans_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/logs.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/logs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/metadata_.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/metadata_.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/processing.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/processing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/resources.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/security.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/security.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/service.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/tasks.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/tasks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_category_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_category_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_category_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_term_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_term_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_term_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_term_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_category_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_category_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_category_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_term_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_term_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_term_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_term_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_category_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_category_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_category_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_term_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_term_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_term_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_term_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossaries_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossaries_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_categories_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_categories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_categories_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_categories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_terms_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_terms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_terms_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_terms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_category_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_category_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_category_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_term_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_term_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_term_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_term_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_cancel_metadata_job_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_cancel_metadata_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_cancel_metadata_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_cancel_metadata_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_aspect_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_aspect_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_group_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_link_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_link_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_metadata_feed_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_metadata_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_metadata_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_metadata_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_aspect_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_aspect_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_group_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_link_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_link_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_metadata_feed_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_metadata_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_aspect_type_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_aspect_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_aspect_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_aspect_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_group_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_group_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_link_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_link_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_type_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_feed_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_feed_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_job_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_aspect_types_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_aspect_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_aspect_types_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_aspect_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entries_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entries_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_groups_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_groups_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_types_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_types_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_feeds_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_feeds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_feeds_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_feeds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_jobs_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_jobs_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_context_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_context_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_context_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_context_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_links_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_links_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_search_entries_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_search_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_search_entries_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_search_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_aspect_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_aspect_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_group_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_link_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_link_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_metadata_feed_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_metadata_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_create_encryption_config_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_create_encryption_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_delete_encryption_config_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_delete_encryption_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_get_encryption_config_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_get_encryption_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_get_encryption_config_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_get_encryption_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_list_encryption_configs_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_list_encryption_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_list_encryption_configs_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_list_encryption_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_update_encryption_config_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_update_encryption_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_create_data_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_create_data_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_create_data_product_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_create_data_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_delete_data_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_delete_data_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_delete_data_product_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_delete_data_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_asset_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_product_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_product_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_assets_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_assets_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_products_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_products_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_update_data_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_update_data_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_update_data_product_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_update_data_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_create_data_scan_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_create_data_scan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_delete_data_scan_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_delete_data_scan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_generate_data_quality_rules_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_generate_data_quality_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_generate_data_quality_rules_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_generate_data_quality_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_job_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scan_jobs_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scan_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scan_jobs_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scan_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scans_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scans_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scans_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scans_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_run_data_scan_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_run_data_scan_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_run_data_scan_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_run_data_scan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_update_data_scan_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_update_data_scan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_attribute_binding_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_attribute_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_attribute_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_taxonomy_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_attribute_binding_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_attribute_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_attribute_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_taxonomy_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_binding_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_binding_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_taxonomy_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_taxonomy_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attribute_bindings_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attribute_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attribute_bindings_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attribute_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attributes_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attributes_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_taxonomies_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_taxonomies_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_attribute_binding_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_attribute_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_attribute_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_taxonomy_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_cancel_job_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_cancel_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_cancel_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_cancel_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_lake_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_lake_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_task_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_zone_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_lake_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_lake_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_task_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_zone_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_asset_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_job_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_lake_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_lake_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_lake_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_lake_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_task_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_task_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_zone_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_zone_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_zone_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_asset_actions_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_asset_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_asset_actions_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_asset_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_assets_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_assets_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_jobs_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_jobs_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lake_actions_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lake_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lake_actions_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lake_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lakes_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lakes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lakes_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lakes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_tasks_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_tasks_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zone_actions_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zone_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zone_actions_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zone_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zones_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zones_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zones_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zones_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_run_task_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_run_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_run_task_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_run_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_lake_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_lake_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_task_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_zone_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_entity_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_entity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_entity_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_entity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_partition_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_partition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_partition_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_entity_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_entity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_entity_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_entity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_partition_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_partition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_partition_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_entity_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_entity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_entity_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_entity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_partition_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_partition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_partition_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_entities_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_entities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_entities_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_partitions_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_partitions_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_update_entity_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_update_entity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_update_entity_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_update_entity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/tests/__init__.py
+++ b/packages/google-cloud-dataplex/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/tests/unit/__init__.py
+++ b/packages/google-cloud-dataplex/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dataplex/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/tests/unit/gapic/dataplex_v1/__init__.py
+++ b/packages/google-cloud-dataplex/tests/unit/gapic/dataplex_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/.flake8
+++ b/packages/google-cloud-dataproc-metastore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/MANIFEST.in
+++ b/packages/google-cloud-dataproc-metastore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore/gapic_version.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/gapic_version.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/metastore.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/metastore_federation.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/metastore_federation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/gapic_version.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/metastore.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/metastore_federation.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/metastore_federation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/gapic_version.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/metastore.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/metastore_federation.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/metastore_federation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_delete_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_delete_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_export_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_export_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_create_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_create_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_delete_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_delete_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_get_federation_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_get_federation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_get_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_get_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_list_federations_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_list_federations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_list_federations_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_list_federations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_update_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_update_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_backup_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_metadata_import_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_metadata_import_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_service_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_backups_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_backups_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_metadata_imports_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_metadata_imports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_metadata_imports_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_metadata_imports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_services_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_services_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_move_table_to_database_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_move_table_to_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_query_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_query_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_restore_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_restore_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_update_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_update_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_update_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_delete_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_delete_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_export_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_export_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_create_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_create_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_delete_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_delete_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_get_federation_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_get_federation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_get_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_get_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_list_federations_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_list_federations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_list_federations_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_list_federations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_update_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_update_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_backup_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_metadata_import_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_metadata_import_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_service_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_backups_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_backups_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_metadata_imports_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_metadata_imports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_metadata_imports_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_metadata_imports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_services_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_services_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_move_table_to_database_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_move_table_to_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_query_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_query_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_remove_iam_policy_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_remove_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_remove_iam_policy_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_remove_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_restore_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_restore_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_update_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_update_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_update_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_delete_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_delete_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_export_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_export_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_create_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_create_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_delete_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_delete_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_get_federation_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_get_federation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_get_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_get_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_list_federations_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_list_federations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_list_federations_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_list_federations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_update_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_update_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_backup_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_metadata_import_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_metadata_import_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_service_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_backups_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_backups_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_metadata_imports_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_metadata_imports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_metadata_imports_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_metadata_imports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_services_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_services_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_move_table_to_database_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_move_table_to_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_query_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_query_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_remove_iam_policy_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_remove_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_remove_iam_policy_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_remove_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_restore_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_restore_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_update_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_update_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_update_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/unit/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1alpha/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1beta/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/.flake8
+++ b/packages/google-cloud-dataproc/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/MANIFEST.in
+++ b/packages/google-cloud-dataproc/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc/gapic_version.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/gapic_version.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/async_client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/async_client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/autoscaling_policies.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/autoscaling_policies.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/batches.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/batches.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/clusters.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/clusters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/jobs.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/jobs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/node_groups.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/node_groups.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/operations.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/session_templates.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/session_templates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/sessions.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/sessions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/shared.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/shared.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/workflow_templates.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/workflow_templates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_create_autoscaling_policy_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_create_autoscaling_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_create_autoscaling_policy_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_create_autoscaling_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_delete_autoscaling_policy_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_delete_autoscaling_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_delete_autoscaling_policy_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_delete_autoscaling_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_get_autoscaling_policy_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_get_autoscaling_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_get_autoscaling_policy_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_get_autoscaling_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_list_autoscaling_policies_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_list_autoscaling_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_list_autoscaling_policies_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_list_autoscaling_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_update_autoscaling_policy_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_update_autoscaling_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_update_autoscaling_policy_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_update_autoscaling_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_create_batch_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_create_batch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_delete_batch_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_delete_batch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_delete_batch_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_delete_batch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_get_batch_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_get_batch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_get_batch_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_get_batch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_list_batches_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_list_batches_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_list_batches_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_list_batches_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_create_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_delete_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_diagnose_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_diagnose_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_get_cluster_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_get_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_list_clusters_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_list_clusters_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_start_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_start_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_stop_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_stop_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_update_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_cancel_job_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_cancel_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_cancel_job_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_cancel_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_delete_job_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_delete_job_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_get_job_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_get_job_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_list_jobs_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_list_jobs_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_as_operation_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_as_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_update_job_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_update_job_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_create_node_group_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_create_node_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_get_node_group_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_get_node_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_get_node_group_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_get_node_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_resize_node_group_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_resize_node_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_create_session_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_delete_session_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_get_session_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_get_session_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_list_sessions_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_list_sessions_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_terminate_session_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_terminate_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_create_session_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_create_session_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_create_session_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_create_session_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_delete_session_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_delete_session_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_delete_session_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_delete_session_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_get_session_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_get_session_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_get_session_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_get_session_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_list_session_templates_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_list_session_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_list_session_templates_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_list_session_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_update_session_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_update_session_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_update_session_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_update_session_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_create_workflow_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_create_workflow_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_create_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_create_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_delete_workflow_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_delete_workflow_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_delete_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_delete_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_get_workflow_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_get_workflow_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_get_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_get_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_instantiate_inline_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_instantiate_inline_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_instantiate_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_instantiate_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_list_workflow_templates_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_list_workflow_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_list_workflow_templates_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_list_workflow_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_update_workflow_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_update_workflow_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_update_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_update_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/tests/__init__.py
+++ b/packages/google-cloud-dataproc/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/tests/unit/__init__.py
+++ b/packages/google-cloud-dataproc/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dataproc/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/tests/unit/gapic/dataproc_v1/__init__.py
+++ b/packages/google-cloud-dataproc/tests/unit/gapic/dataproc_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/.flake8
+++ b/packages/google-cloud-datastore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/MANIFEST.in
+++ b/packages/google-cloud-datastore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore/gapic_version.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin/gapic_version.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/gapic_version.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/client.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/pagers.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/base.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/grpc.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/rest.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/rest_base.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/datastore_admin.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/datastore_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/index.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/index.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/migration.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/migration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/gapic_version.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/async_client.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/client.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/base.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/grpc.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/rest.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/rest_base.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/aggregation_result.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/aggregation_result.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/datastore.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/datastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/entity.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/entity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/query.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/query_profile.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/query_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_create_index_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_create_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_delete_index_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_delete_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_export_entities_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_export_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_get_index_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_get_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_get_index_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_get_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_import_entities_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_import_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_list_indexes_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_list_indexes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_list_indexes_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_list_indexes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_allocate_ids_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_allocate_ids_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_allocate_ids_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_allocate_ids_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_begin_transaction_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_begin_transaction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_begin_transaction_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_begin_transaction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_commit_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_commit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_commit_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_commit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_lookup_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_lookup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_lookup_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_lookup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_reserve_ids_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_reserve_ids_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_reserve_ids_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_reserve_ids_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_rollback_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_rollback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_rollback_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_rollback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_aggregation_query_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_aggregation_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_aggregation_query_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_aggregation_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_query_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_query_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/tests/__init__.py
+++ b/packages/google-cloud-datastore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/tests/unit/__init__.py
+++ b/packages/google-cloud-datastore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-datastore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/tests/unit/gapic/datastore_admin_v1/__init__.py
+++ b/packages/google-cloud-datastore/tests/unit/gapic/datastore_admin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/tests/unit/gapic/datastore_v1/__init__.py
+++ b/packages/google-cloud-datastore/tests/unit/gapic/datastore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/.flake8
+++ b/packages/google-cloud-datastream/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/MANIFEST.in
+++ b/packages/google-cloud-datastream/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream/gapic_version.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/gapic_version.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/client.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/pagers.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/base.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/grpc.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/rest.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/rest_base.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/types/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/types/datastream.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/types/datastream.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/types/datastream_resources.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/types/datastream_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/client.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/pagers.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/base.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/grpc.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/rest.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/rest_base.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/datastream.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/datastream.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/datastream_resources.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/datastream_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_discover_connection_profile_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_discover_connection_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_discover_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_discover_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_fetch_static_ips_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_fetch_static_ips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_fetch_static_ips_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_fetch_static_ips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_connection_profile_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_connection_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_private_connection_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_private_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_route_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_object_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_object_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_connection_profiles_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_connection_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_connection_profiles_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_connection_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_private_connections_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_private_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_private_connections_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_private_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_routes_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_routes_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_stream_objects_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_stream_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_stream_objects_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_stream_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_streams_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_streams_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_lookup_stream_object_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_lookup_stream_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_lookup_stream_object_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_lookup_stream_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_run_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_run_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_start_backfill_job_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_start_backfill_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_start_backfill_job_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_start_backfill_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_stop_backfill_job_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_stop_backfill_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_stop_backfill_job_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_stop_backfill_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_update_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_update_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_update_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_update_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_discover_connection_profile_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_discover_connection_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_discover_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_discover_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_errors_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_static_ips_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_static_ips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_static_ips_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_static_ips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_connection_profile_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_connection_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_private_connection_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_private_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_route_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_stream_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_connection_profiles_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_connection_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_connection_profiles_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_connection_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_private_connections_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_private_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_private_connections_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_private_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_routes_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_routes_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_streams_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_streams_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_update_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_update_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_update_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_update_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/tests/__init__.py
+++ b/packages/google-cloud-datastream/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/tests/unit/__init__.py
+++ b/packages/google-cloud-datastream/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-datastream/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/tests/unit/gapic/datastream_v1/__init__.py
+++ b/packages/google-cloud-datastream/tests/unit/gapic/datastream_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/tests/unit/gapic/datastream_v1alpha1/__init__.py
+++ b/packages/google-cloud-datastream/tests/unit/gapic/datastream_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/.flake8
+++ b/packages/google-cloud-deploy/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/MANIFEST.in
+++ b/packages/google-cloud-deploy/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy/__init__.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy/gapic_version.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/gapic_version.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/__init__.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/__init__.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/client.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/pagers.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/__init__.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/base.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/grpc.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/grpc_asyncio.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/rest.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/rest_base.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/__init__.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/automation_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/automation_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/automationrun_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/automationrun_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/cloud_deploy.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/cloud_deploy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/customtargettype_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/customtargettype_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deliverypipeline_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deliverypipeline_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deploypolicy_evaluation_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deploypolicy_evaluation_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deploypolicy_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deploypolicy_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/jobrun_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/jobrun_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/log_enums.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/log_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/release_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/release_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/release_render_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/release_render_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/rollout_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/rollout_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/rollout_update_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/rollout_update_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/target_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/target_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_abandon_release_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_abandon_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_abandon_release_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_abandon_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_advance_rollout_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_advance_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_advance_rollout_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_advance_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_approve_rollout_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_approve_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_approve_rollout_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_approve_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_automation_run_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_automation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_automation_run_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_automation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_rollout_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_rollout_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_automation_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_automation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_custom_target_type_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_custom_target_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_delivery_pipeline_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_delivery_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_deploy_policy_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_deploy_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_release_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_rollout_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_target_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_automation_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_automation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_custom_target_type_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_custom_target_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_delivery_pipeline_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_delivery_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_deploy_policy_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_deploy_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_target_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_run_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_run_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_config_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_config_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_custom_target_type_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_custom_target_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_custom_target_type_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_custom_target_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_delivery_pipeline_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_delivery_pipeline_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_delivery_pipeline_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_delivery_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_deploy_policy_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_deploy_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_deploy_policy_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_deploy_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_job_run_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_job_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_job_run_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_job_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_release_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_release_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_rollout_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_rollout_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_target_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_target_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_target_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_ignore_job_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_ignore_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_ignore_job_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_ignore_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automation_runs_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automation_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automation_runs_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automation_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automations_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automations_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_custom_target_types_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_custom_target_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_custom_target_types_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_custom_target_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_delivery_pipelines_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_delivery_pipelines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_delivery_pipelines_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_delivery_pipelines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_deploy_policies_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_deploy_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_deploy_policies_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_deploy_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_job_runs_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_job_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_job_runs_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_job_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_releases_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_releases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_releases_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_releases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_rollouts_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_rollouts_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_targets_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_targets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_targets_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_targets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_retry_job_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_retry_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_retry_job_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_retry_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_rollback_target_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_rollback_target_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_rollback_target_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_rollback_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_terminate_job_run_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_terminate_job_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_terminate_job_run_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_terminate_job_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_automation_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_automation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_custom_target_type_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_custom_target_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_delivery_pipeline_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_delivery_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_deploy_policy_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_deploy_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_target_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/tests/__init__.py
+++ b/packages/google-cloud-deploy/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/tests/unit/__init__.py
+++ b/packages/google-cloud-deploy/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-deploy/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/tests/unit/gapic/deploy_v1/__init__.py
+++ b/packages/google-cloud-deploy/tests/unit/gapic/deploy_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/.flake8
+++ b/packages/google-cloud-developerconnect/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/MANIFEST.in
+++ b/packages/google-cloud-developerconnect/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect/gapic_version.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/gapic_version.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/client.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/pagers.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/base.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/grpc.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/grpc_asyncio.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/rest.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/rest_base.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/client.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/pagers.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/base.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/grpc.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/rest.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/rest_base.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/developer_connect.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/developer_connect.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/insights_config.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/insights_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_account_connector_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_account_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_connection_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_git_repository_link_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_git_repository_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_account_connector_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_account_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_connection_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_git_repository_link_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_git_repository_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_self_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_self_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_user_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_access_token_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_access_token_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_hub_installations_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_hub_installations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_hub_installations_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_hub_installations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_refs_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_refs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_refs_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_refs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_linkable_git_repositories_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_linkable_git_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_linkable_git_repositories_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_linkable_git_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_token_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_token_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_write_token_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_write_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_write_token_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_write_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_self_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_self_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_self_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_self_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_finish_o_auth_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_finish_o_auth_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_finish_o_auth_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_finish_o_auth_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_account_connector_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_account_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_account_connector_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_account_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_connection_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_connection_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_git_repository_link_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_git_repository_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_git_repository_link_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_git_repository_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_account_connectors_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_account_connectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_account_connectors_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_account_connectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_connections_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_connections_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_git_repository_links_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_git_repository_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_git_repository_links_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_git_repository_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_users_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_users_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_start_o_auth_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_start_o_auth_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_start_o_auth_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_start_o_auth_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_update_account_connector_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_update_account_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_update_connection_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_update_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_create_insights_config_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_create_insights_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_delete_insights_config_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_delete_insights_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_deployment_event_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_deployment_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_deployment_event_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_deployment_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_insights_config_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_insights_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_insights_config_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_insights_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_deployment_events_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_deployment_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_deployment_events_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_deployment_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_insights_configs_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_insights_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_insights_configs_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_insights_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_update_insights_config_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_update_insights_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/tests/__init__.py
+++ b/packages/google-cloud-developerconnect/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/tests/unit/__init__.py
+++ b/packages/google-cloud-developerconnect/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-developerconnect/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/tests/unit/gapic/developerconnect_v1/__init__.py
+++ b/packages/google-cloud-developerconnect/tests/unit/gapic/developerconnect_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/.flake8
+++ b/packages/google-cloud-devicestreaming/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/MANIFEST.in
+++ b/packages/google-cloud-devicestreaming/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming/__init__.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming/gapic_version.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/gapic_version.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/__init__.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/__init__.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/async_client.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/client.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/pagers.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/__init__.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/base.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/grpc.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/rest.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/rest_base.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/__init__.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/adb_service.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/adb_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/service.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_adb_connect_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_adb_connect_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_adb_connect_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_adb_connect_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_cancel_device_session_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_cancel_device_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_cancel_device_session_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_cancel_device_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_create_device_session_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_create_device_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_create_device_session_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_create_device_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_get_device_session_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_get_device_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_get_device_session_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_get_device_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_list_device_sessions_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_list_device_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_list_device_sessions_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_list_device_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_update_device_session_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_update_device_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_update_device_session_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_update_device_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/tests/__init__.py
+++ b/packages/google-cloud-devicestreaming/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/tests/unit/__init__.py
+++ b/packages/google-cloud-devicestreaming/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-devicestreaming/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/tests/unit/gapic/devicestreaming_v1/__init__.py
+++ b/packages/google-cloud-devicestreaming/tests/unit/gapic/devicestreaming_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/.flake8
+++ b/packages/google-cloud-dialogflow-cx/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/MANIFEST.in
+++ b/packages/google-cloud-dialogflow-cx/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx/gapic_version.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/gapic_version.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/advanced_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/advanced_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/agent.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/audio_config.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/audio_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/changelog.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/changelog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/code_block.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/code_block.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/data_store_connection.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/data_store_connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/deployment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/entity_type.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/entity_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/environment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/environment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/example.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/example.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/experiment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/experiment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/flow.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/flow.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/fulfillment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/fulfillment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/gcs.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/gcs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/generative_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/generative_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/generator.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/import_strategy.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/import_strategy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/inline.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/inline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/intent.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/intent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/page.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/page.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/parameter_definition.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/parameter_definition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/playbook.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/playbook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/response_message.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/response_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/safety_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/safety_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/security_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/security_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/session.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/session_entity_type.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/session_entity_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/test_case.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/test_case.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/tool.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/tool_call.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/tool_call.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/trace.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/transition_route_group.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/transition_route_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/validation_message.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/validation_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/version.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/webhook.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/webhook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/gapic_version.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/advanced_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/advanced_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/agent.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/audio_config.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/audio_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/bigquery_export.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/bigquery_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/changelog.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/changelog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/code_block.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/code_block.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/conversation_history.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/conversation_history.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/data_store_connection.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/data_store_connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/deployment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/entity_type.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/entity_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/environment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/environment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/example.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/example.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/experiment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/experiment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/flow.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/flow.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/fulfillment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/fulfillment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/gcs.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/gcs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/generative_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/generative_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/generator.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/import_strategy.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/import_strategy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/inline.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/inline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/intent.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/intent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/page.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/page.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/parameter_definition.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/parameter_definition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/playbook.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/playbook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/response_message.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/response_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/safety_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/safety_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/security_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/security_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/session.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/session_entity_type.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/session_entity_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/test_case.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/test_case.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/tool.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/tool_call.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/tool_call.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/trace.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/transition_route_group.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/transition_route_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/validation_message.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/validation_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/version.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/webhook.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/webhook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_create_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_create_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_create_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_create_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_delete_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_delete_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_delete_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_delete_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_export_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_export_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_validation_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_validation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_validation_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_validation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_generative_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_generative_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_generative_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_generative_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_list_agents_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_list_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_list_agents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_list_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_restore_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_restore_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_generative_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_generative_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_generative_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_generative_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_validate_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_validate_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_validate_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_validate_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_get_changelog_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_get_changelog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_get_changelog_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_get_changelog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_list_changelogs_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_list_changelogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_list_changelogs_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_list_changelogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_get_deployment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_get_deployment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_list_deployments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_list_deployments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_create_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_create_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_create_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_create_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_delete_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_delete_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_delete_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_delete_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_export_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_export_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_get_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_get_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_get_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_get_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_import_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_import_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_list_entity_types_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_list_entity_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_list_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_list_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_update_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_update_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_update_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_update_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_create_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_delete_environment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_delete_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_delete_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_deploy_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_deploy_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_get_environment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_get_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_continuous_test_results_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_continuous_test_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_continuous_test_results_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_continuous_test_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_environments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_environments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_lookup_environment_history_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_lookup_environment_history_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_lookup_environment_history_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_lookup_environment_history_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_run_continuous_test_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_run_continuous_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_update_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_update_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_create_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_create_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_create_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_create_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_delete_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_delete_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_delete_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_delete_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_get_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_get_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_get_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_get_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_list_examples_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_list_examples_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_update_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_update_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_update_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_update_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_create_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_create_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_create_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_create_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_delete_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_delete_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_delete_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_delete_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_get_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_get_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_get_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_get_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_list_experiments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_list_experiments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_list_experiments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_list_experiments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_start_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_start_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_start_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_start_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_stop_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_stop_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_stop_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_stop_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_update_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_update_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_update_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_update_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_create_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_create_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_create_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_create_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_delete_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_delete_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_delete_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_delete_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_export_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_export_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_validation_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_validation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_validation_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_validation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_import_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_import_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_list_flows_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_list_flows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_list_flows_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_list_flows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_train_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_train_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_update_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_update_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_update_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_update_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_validate_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_validate_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_validate_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_validate_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_create_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_create_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_create_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_create_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_delete_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_delete_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_delete_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_delete_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_get_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_get_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_get_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_get_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_list_generators_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_list_generators_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_list_generators_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_list_generators_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_update_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_update_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_update_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_update_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_create_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_create_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_create_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_create_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_delete_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_delete_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_delete_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_delete_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_export_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_export_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_get_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_get_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_get_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_get_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_import_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_import_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_list_intents_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_list_intents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_list_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_list_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_update_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_update_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_update_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_update_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_create_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_create_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_create_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_create_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_delete_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_delete_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_delete_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_delete_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_get_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_get_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_get_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_get_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_list_pages_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_list_pages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_list_pages_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_list_pages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_update_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_update_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_update_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_update_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_export_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_export_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_import_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_import_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbook_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbook_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbook_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbook_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbooks_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbooks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbooks_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbooks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_restore_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_restore_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_restore_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_restore_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_update_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_update_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_update_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_update_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_create_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_create_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_create_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_create_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_delete_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_delete_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_delete_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_delete_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_get_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_get_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_get_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_get_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_list_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_list_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_list_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_list_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_update_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_update_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_update_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_update_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_create_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_create_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_create_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_create_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_delete_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_delete_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_delete_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_delete_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_get_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_get_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_get_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_get_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_list_session_entity_types_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_list_session_entity_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_list_session_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_list_session_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_update_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_update_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_update_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_update_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_fulfill_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_fulfill_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_fulfill_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_fulfill_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_match_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_match_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_match_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_match_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_server_streaming_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_server_streaming_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_server_streaming_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_server_streaming_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_streaming_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_streaming_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_streaming_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_streaming_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_submit_answer_feedback_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_submit_answer_feedback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_submit_answer_feedback_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_submit_answer_feedback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_delete_test_cases_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_delete_test_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_delete_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_delete_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_run_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_run_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_calculate_coverage_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_calculate_coverage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_calculate_coverage_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_calculate_coverage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_create_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_create_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_create_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_create_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_export_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_export_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_import_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_import_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_case_results_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_case_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_case_results_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_case_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_cases_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_run_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_run_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_update_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_update_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_update_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_update_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tool_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tool_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tool_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tool_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tools_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tools_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_restore_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_restore_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_restore_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_restore_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_update_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_update_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_update_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_update_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_create_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_create_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_create_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_create_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_delete_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_delete_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_delete_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_delete_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_get_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_get_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_get_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_get_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_list_transition_route_groups_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_list_transition_route_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_list_transition_route_groups_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_list_transition_route_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_update_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_update_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_update_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_update_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_compare_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_compare_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_compare_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_compare_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_create_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_create_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_delete_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_delete_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_delete_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_get_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_get_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_list_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_list_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_load_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_load_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_update_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_update_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_update_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_update_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_create_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_create_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_create_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_create_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_delete_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_delete_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_delete_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_delete_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_get_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_get_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_get_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_get_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_list_webhooks_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_list_webhooks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_list_webhooks_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_list_webhooks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_update_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_update_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_update_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_update_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_create_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_create_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_create_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_create_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_delete_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_delete_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_delete_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_delete_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_export_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_export_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_validation_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_validation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_validation_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_validation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_generative_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_generative_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_generative_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_generative_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_list_agents_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_list_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_list_agents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_list_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_restore_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_restore_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_generative_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_generative_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_generative_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_generative_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_validate_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_validate_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_validate_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_validate_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_get_changelog_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_get_changelog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_get_changelog_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_get_changelog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_list_changelogs_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_list_changelogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_list_changelogs_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_list_changelogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_delete_conversation_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_delete_conversation_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_get_conversation_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_get_conversation_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_list_conversations_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_list_conversations_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_get_deployment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_get_deployment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_list_deployments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_list_deployments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_create_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_create_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_create_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_create_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_delete_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_delete_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_delete_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_delete_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_export_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_export_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_get_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_get_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_get_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_get_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_import_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_import_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_list_entity_types_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_list_entity_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_list_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_list_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_update_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_update_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_update_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_update_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_create_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_delete_environment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_delete_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_delete_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_deploy_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_deploy_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_get_environment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_get_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_continuous_test_results_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_continuous_test_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_continuous_test_results_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_continuous_test_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_environments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_environments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_lookup_environment_history_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_lookup_environment_history_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_lookup_environment_history_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_lookup_environment_history_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_run_continuous_test_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_run_continuous_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_update_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_update_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_create_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_create_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_create_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_create_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_delete_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_delete_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_delete_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_delete_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_get_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_get_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_get_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_get_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_list_examples_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_list_examples_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_update_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_update_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_update_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_update_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_create_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_create_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_create_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_create_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_delete_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_delete_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_delete_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_delete_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_get_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_get_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_get_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_get_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_list_experiments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_list_experiments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_list_experiments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_list_experiments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_start_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_start_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_start_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_start_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_stop_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_stop_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_stop_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_stop_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_update_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_update_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_update_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_update_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_create_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_create_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_create_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_create_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_delete_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_delete_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_delete_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_delete_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_export_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_export_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_validation_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_validation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_validation_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_validation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_import_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_import_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_list_flows_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_list_flows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_list_flows_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_list_flows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_train_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_train_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_update_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_update_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_update_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_update_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_validate_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_validate_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_validate_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_validate_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_create_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_create_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_create_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_create_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_delete_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_delete_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_delete_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_delete_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_get_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_get_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_get_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_get_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_list_generators_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_list_generators_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_list_generators_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_list_generators_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_update_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_update_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_update_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_update_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_create_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_create_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_create_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_create_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_delete_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_delete_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_delete_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_delete_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_export_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_export_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_get_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_get_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_get_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_get_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_import_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_import_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_list_intents_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_list_intents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_list_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_list_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_update_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_update_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_update_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_update_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_create_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_create_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_create_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_create_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_delete_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_delete_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_delete_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_delete_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_get_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_get_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_get_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_get_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_list_pages_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_list_pages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_list_pages_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_list_pages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_update_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_update_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_update_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_update_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_export_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_export_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_import_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_import_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbook_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbook_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbook_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbook_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbooks_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbooks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbooks_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbooks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_restore_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_restore_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_restore_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_restore_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_update_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_update_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_update_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_update_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_create_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_create_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_create_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_create_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_delete_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_delete_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_delete_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_delete_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_get_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_get_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_get_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_get_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_list_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_list_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_list_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_list_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_update_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_update_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_update_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_update_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_create_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_create_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_create_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_create_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_delete_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_delete_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_delete_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_delete_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_get_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_get_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_get_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_get_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_list_session_entity_types_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_list_session_entity_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_list_session_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_list_session_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_update_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_update_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_update_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_update_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_fulfill_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_fulfill_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_fulfill_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_fulfill_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_match_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_match_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_match_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_match_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_server_streaming_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_server_streaming_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_server_streaming_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_server_streaming_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_streaming_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_streaming_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_streaming_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_streaming_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_submit_answer_feedback_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_submit_answer_feedback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_submit_answer_feedback_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_submit_answer_feedback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_delete_test_cases_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_delete_test_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_delete_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_delete_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_run_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_run_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_calculate_coverage_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_calculate_coverage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_calculate_coverage_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_calculate_coverage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_create_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_create_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_create_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_create_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_export_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_export_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_import_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_import_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_case_results_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_case_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_case_results_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_case_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_cases_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_run_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_run_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_update_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_update_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_update_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_update_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_export_tools_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_export_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tool_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tool_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tool_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tool_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tools_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tools_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_restore_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_restore_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_restore_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_restore_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_update_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_update_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_update_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_update_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_create_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_create_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_create_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_create_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_delete_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_delete_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_delete_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_delete_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_get_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_get_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_get_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_get_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_list_transition_route_groups_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_list_transition_route_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_list_transition_route_groups_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_list_transition_route_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_update_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_update_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_update_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_update_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_compare_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_compare_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_compare_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_compare_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_create_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_create_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_delete_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_delete_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_delete_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_get_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_get_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_list_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_list_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_load_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_load_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_update_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_update_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_update_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_update_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_create_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_create_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_create_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_create_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_delete_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_delete_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_delete_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_delete_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_get_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_get_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_get_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_get_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_list_webhooks_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_list_webhooks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_list_webhooks_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_list_webhooks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_update_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_update_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_update_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_update_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/tests/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/tests/unit/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/tests/unit/gapic/dialogflowcx_v3/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/tests/unit/gapic/dialogflowcx_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/tests/unit/gapic/dialogflowcx_v3beta1/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/tests/unit/gapic/dialogflowcx_v3beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/.flake8
+++ b/packages/google-cloud-discoveryengine/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/MANIFEST.in
+++ b/packages/google-cloud-discoveryengine/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine/gapic_version.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/gapic_version.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/answer.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/answer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assist_answer.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assist_answer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assistant.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assistant.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assistant_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assistant_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/chunk.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/chunk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/cmek_config_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/cmek_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/common.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/completion.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/completion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/completion_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/control.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/control_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/conversation.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/conversational_search_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/custom_tuning_model.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/custom_tuning_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/data_store.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/data_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/data_store_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/data_store_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document_processing_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document_processing_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/grounded_generation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/grounded_generation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/grounding.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/grounding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/identity_mapping_store.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/identity_mapping_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/identity_mapping_store_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/identity_mapping_store_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/import_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/project.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/project.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/project_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/project_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/purge_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/rank_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/rank_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/recommendation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/recommendation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/safety.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/schema.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/schema_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/schema_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/search_tuning_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/search_tuning_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/serving_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/serving_config_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/session.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/session_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/session_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/site_search_engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/site_search_engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/site_search_engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/site_search_engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_event.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_event_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_license.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_license.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_license_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_license_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/gapic_version.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/acl_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/acl_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/acl_config_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/acl_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/answer.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/answer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/chunk.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/chunk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/chunk_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/chunk_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/common.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/completion.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/completion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/completion_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/control.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/control_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/conversation.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/conversational_search_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/custom_tuning_model.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/custom_tuning_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/data_store.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/data_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/data_store_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/data_store_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document_processing_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document_processing_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/estimate_billing_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/estimate_billing_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/evaluation.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/evaluation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/evaluation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/grounded_generation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/grounded_generation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/grounding.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/grounding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/import_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/project.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/project.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/project_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/project_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/purge_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/rank_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/rank_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/recommendation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/recommendation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_set.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_set_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_set_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/schema.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/schema_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/schema_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/search_tuning_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/search_tuning_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/serving_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/serving_config_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/session.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/session_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/session_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/site_search_engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/site_search_engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/site_search_engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/site_search_engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/user_event.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/user_event_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/gapic_version.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/answer.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/answer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/chunk.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/chunk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/common.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/completion.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/completion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/completion_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/control.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/control_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/conversation.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/conversational_search_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/custom_tuning_model.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/custom_tuning_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/data_store.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/data_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/data_store_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/data_store_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document_processing_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document_processing_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/evaluation.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/evaluation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/evaluation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/grounded_generation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/grounded_generation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/grounding.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/grounding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/import_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/project.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/project.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/project_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/project_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/purge_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/rank_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/rank_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/recommendation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/recommendation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_set.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_set_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_set_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/schema.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/schema_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/schema_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/search_tuning_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/search_tuning_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/serving_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/serving_config_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/session.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/session_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/session_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/site_search_engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/site_search_engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/site_search_engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/site_search_engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/user_event.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/user_event_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_assistant_service_stream_assist_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_assistant_service_stream_assist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_assistant_service_stream_assist_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_assistant_service_stream_assist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_delete_cmek_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_delete_cmek_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_get_cmek_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_get_cmek_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_get_cmek_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_get_cmek_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_list_cmek_configs_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_list_cmek_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_list_cmek_configs_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_list_cmek_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_update_cmek_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_update_cmek_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_import_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_import_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_import_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_import_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_purge_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_purge_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_answer_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_answer_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_answer_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_answer_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_converse_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_converse_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_converse_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_converse_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_answer_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_answer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_answer_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_answer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_conversations_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_conversations_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_stream_answer_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_stream_answer_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_stream_answer_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_stream_answer_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_create_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_create_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_delete_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_delete_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_get_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_get_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_get_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_get_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_list_data_stores_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_list_data_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_list_data_stores_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_list_data_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_update_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_update_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_update_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_update_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_batch_get_documents_metadata_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_batch_get_documents_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_batch_get_documents_metadata_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_batch_get_documents_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_create_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_create_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_delete_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_delete_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_get_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_get_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_import_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_import_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_list_documents_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_list_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_purge_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_purge_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_update_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_update_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_create_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_create_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_delete_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_delete_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_get_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_get_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_get_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_get_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_list_engines_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_list_engines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_list_engines_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_list_engines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_update_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_update_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_update_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_update_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_check_grounding_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_check_grounding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_check_grounding_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_check_grounding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_generate_grounded_content_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_generate_grounded_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_generate_grounded_content_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_generate_grounded_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_stream_generate_grounded_content_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_stream_generate_grounded_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_stream_generate_grounded_content_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_stream_generate_grounded_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_create_identity_mapping_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_create_identity_mapping_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_create_identity_mapping_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_create_identity_mapping_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_delete_identity_mapping_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_delete_identity_mapping_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_get_identity_mapping_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_get_identity_mapping_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_get_identity_mapping_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_get_identity_mapping_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_import_identity_mappings_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_import_identity_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mapping_stores_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mapping_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mapping_stores_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mapping_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mappings_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mappings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mappings_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_purge_identity_mappings_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_purge_identity_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_project_service_provision_project_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_project_service_provision_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_rank_service_rank_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_rank_service_rank_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_rank_service_rank_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_rank_service_rank_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_recommendation_service_recommend_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_recommendation_service_recommend_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_recommendation_service_recommend_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_recommendation_service_recommend_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_create_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_create_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_delete_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_delete_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_get_schema_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_get_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_get_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_get_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_list_schemas_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_list_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_list_schemas_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_list_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_update_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_update_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_lite_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_lite_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_lite_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_lite_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_list_custom_models_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_list_custom_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_list_custom_models_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_list_custom_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_train_custom_model_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_train_custom_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_batch_create_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_batch_create_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_batch_verify_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_batch_verify_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_create_sitemap_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_create_sitemap_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_create_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_create_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_delete_sitemap_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_delete_sitemap_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_delete_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_delete_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_disable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_disable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_enable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_enable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_domain_verification_status_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_domain_verification_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_sitemaps_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_sitemaps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_sitemaps_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_sitemaps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_site_search_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_site_search_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_site_search_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_site_search_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_target_site_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_target_site_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_list_target_sites_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_list_target_sites_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_list_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_list_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_recrawl_uris_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_recrawl_uris_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_update_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_update_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_batch_update_user_licenses_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_batch_update_user_licenses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_list_user_licenses_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_list_user_licenses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_list_user_licenses_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_list_user_licenses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_get_acl_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_get_acl_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_get_acl_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_get_acl_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_update_acl_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_update_acl_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_update_acl_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_update_acl_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_get_chunk_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_get_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_get_chunk_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_get_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_list_chunks_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_list_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_list_chunks_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_list_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_import_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_import_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_import_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_import_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_purge_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_purge_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_answer_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_answer_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_answer_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_answer_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_converse_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_converse_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_converse_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_converse_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_answer_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_answer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_answer_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_answer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_conversations_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_conversations_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_create_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_create_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_delete_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_delete_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_document_processing_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_document_processing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_document_processing_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_document_processing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_list_data_stores_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_list_data_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_list_data_stores_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_list_data_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_document_processing_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_document_processing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_document_processing_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_document_processing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_batch_get_documents_metadata_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_batch_get_documents_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_batch_get_documents_metadata_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_batch_get_documents_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_create_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_create_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_delete_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_delete_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_processed_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_processed_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_processed_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_processed_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_import_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_import_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_list_documents_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_list_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_purge_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_purge_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_update_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_update_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_create_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_create_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_delete_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_delete_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_get_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_get_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_get_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_get_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_list_engines_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_list_engines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_list_engines_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_list_engines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_pause_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_pause_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_pause_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_pause_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_resume_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_resume_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_resume_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_resume_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_tune_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_tune_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_update_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_update_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_update_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_update_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_estimate_billing_service_estimate_data_size_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_estimate_billing_service_estimate_data_size_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_create_evaluation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_create_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_get_evaluation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_get_evaluation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluation_results_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluation_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluation_results_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluation_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluations_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluations_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_grounded_generation_service_check_grounding_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_grounded_generation_service_check_grounding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_grounded_generation_service_check_grounding_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_grounded_generation_service_check_grounding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_get_project_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_get_project_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_get_project_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_get_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_provision_project_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_provision_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_report_consent_change_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_report_consent_change_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_report_consent_change_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_report_consent_change_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_rank_service_rank_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_rank_service_rank_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_rank_service_rank_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_rank_service_rank_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_recommendation_service_recommend_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_recommendation_service_recommend_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_recommendation_service_recommend_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_recommendation_service_recommend_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_create_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_create_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_create_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_create_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_delete_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_delete_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_delete_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_delete_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_get_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_get_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_get_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_get_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_import_sample_queries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_import_sample_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_list_sample_queries_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_list_sample_queries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_list_sample_queries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_list_sample_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_update_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_update_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_update_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_update_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_create_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_create_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_create_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_create_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_delete_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_delete_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_delete_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_delete_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_get_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_get_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_get_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_get_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_list_sample_query_sets_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_list_sample_query_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_list_sample_query_sets_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_list_sample_query_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_update_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_update_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_update_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_update_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_create_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_create_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_delete_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_delete_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_get_schema_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_get_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_get_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_get_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_list_schemas_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_list_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_list_schemas_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_list_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_update_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_update_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_service_search_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_service_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_list_custom_models_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_list_custom_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_list_custom_models_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_list_custom_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_train_custom_model_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_train_custom_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_get_serving_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_get_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_get_serving_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_get_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_list_serving_configs_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_list_serving_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_list_serving_configs_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_list_serving_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_files_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_files_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_batch_create_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_batch_create_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_batch_verify_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_batch_verify_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_create_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_create_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_delete_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_delete_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_disable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_disable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_enable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_enable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_fetch_domain_verification_status_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_fetch_domain_verification_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_site_search_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_site_search_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_site_search_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_site_search_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_target_site_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_target_site_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_uri_pattern_document_data_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_uri_pattern_document_data_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_uri_pattern_document_data_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_uri_pattern_document_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_list_target_sites_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_list_target_sites_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_list_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_list_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_recrawl_uris_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_recrawl_uris_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_set_uri_pattern_document_data_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_set_uri_pattern_document_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_update_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_update_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_advanced_complete_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_advanced_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_advanced_complete_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_advanced_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_import_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_import_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_import_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_import_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_purge_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_purge_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_answer_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_answer_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_answer_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_answer_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_converse_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_converse_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_converse_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_converse_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_answer_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_answer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_answer_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_answer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_conversations_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_conversations_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_create_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_create_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_delete_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_delete_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_get_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_get_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_get_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_get_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_list_data_stores_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_list_data_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_list_data_stores_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_list_data_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_update_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_update_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_update_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_update_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_batch_get_documents_metadata_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_batch_get_documents_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_batch_get_documents_metadata_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_batch_get_documents_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_create_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_create_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_delete_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_delete_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_get_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_get_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_import_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_import_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_list_documents_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_list_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_purge_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_purge_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_update_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_update_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_create_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_create_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_delete_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_delete_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_get_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_get_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_get_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_get_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_list_engines_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_list_engines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_list_engines_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_list_engines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_pause_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_pause_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_pause_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_pause_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_resume_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_resume_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_resume_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_resume_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_tune_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_tune_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_update_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_update_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_update_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_update_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_create_evaluation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_create_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_get_evaluation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_get_evaluation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluation_results_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluation_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluation_results_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluation_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluations_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluations_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_check_grounding_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_check_grounding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_check_grounding_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_check_grounding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_generate_grounded_content_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_generate_grounded_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_generate_grounded_content_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_generate_grounded_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_stream_generate_grounded_content_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_stream_generate_grounded_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_stream_generate_grounded_content_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_stream_generate_grounded_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_project_service_provision_project_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_project_service_provision_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_rank_service_rank_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_rank_service_rank_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_rank_service_rank_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_rank_service_rank_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_recommendation_service_recommend_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_recommendation_service_recommend_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_recommendation_service_recommend_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_recommendation_service_recommend_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_create_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_create_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_create_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_create_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_delete_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_delete_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_delete_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_delete_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_get_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_get_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_get_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_get_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_import_sample_queries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_import_sample_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_list_sample_queries_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_list_sample_queries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_list_sample_queries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_list_sample_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_update_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_update_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_update_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_update_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_create_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_create_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_create_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_create_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_delete_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_delete_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_delete_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_delete_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_get_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_get_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_get_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_get_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_list_sample_query_sets_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_list_sample_query_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_list_sample_query_sets_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_list_sample_query_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_update_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_update_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_update_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_update_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_create_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_create_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_delete_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_delete_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_get_schema_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_get_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_get_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_get_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_list_schemas_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_list_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_list_schemas_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_list_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_update_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_update_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_lite_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_lite_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_lite_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_lite_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_list_custom_models_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_list_custom_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_list_custom_models_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_list_custom_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_train_custom_model_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_train_custom_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_get_serving_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_get_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_get_serving_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_get_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_list_serving_configs_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_list_serving_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_list_serving_configs_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_list_serving_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_batch_create_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_batch_create_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_batch_verify_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_batch_verify_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_create_sitemap_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_create_sitemap_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_create_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_create_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_delete_sitemap_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_delete_sitemap_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_delete_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_delete_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_disable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_disable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_enable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_enable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_domain_verification_status_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_domain_verification_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_sitemaps_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_sitemaps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_sitemaps_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_sitemaps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_site_search_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_site_search_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_site_search_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_site_search_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_target_site_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_target_site_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_list_target_sites_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_list_target_sites_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_list_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_list_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_recrawl_uris_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_recrawl_uris_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_update_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_update_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/unit/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1alpha/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1beta/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/.flake8
+++ b/packages/google-cloud-dlp/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/MANIFEST.in
+++ b/packages/google-cloud-dlp/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp/__init__.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp/gapic_version.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/gapic_version.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/__init__.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/__init__.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/async_client.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/client.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/pagers.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/__init__.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/base.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/grpc.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/rest.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/rest_base.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/types/__init__.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/types/dlp.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/types/dlp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/types/storage.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/types/storage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_activate_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_activate_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_activate_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_activate_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_cancel_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_cancel_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_cancel_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_cancel_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_connection_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_connection_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_deidentify_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_deidentify_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_deidentify_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_deidentify_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_discovery_config_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_discovery_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_discovery_config_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_discovery_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_inspect_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_inspect_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_inspect_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_inspect_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_stored_info_type_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_stored_info_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_stored_info_type_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_stored_info_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_deidentify_content_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_deidentify_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_deidentify_content_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_deidentify_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_connection_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_connection_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_deidentify_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_deidentify_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_deidentify_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_deidentify_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_discovery_config_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_discovery_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_discovery_config_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_discovery_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_file_store_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_file_store_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_file_store_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_file_store_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_inspect_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_inspect_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_inspect_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_inspect_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_stored_info_type_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_stored_info_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_stored_info_type_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_stored_info_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_table_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_table_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_table_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_table_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_finish_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_finish_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_finish_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_finish_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_column_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_column_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_column_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_column_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_connection_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_connection_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_deidentify_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_deidentify_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_deidentify_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_deidentify_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_discovery_config_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_discovery_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_discovery_config_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_discovery_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_file_store_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_file_store_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_file_store_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_file_store_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_inspect_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_inspect_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_inspect_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_inspect_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_project_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_project_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_project_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_project_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_stored_info_type_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_stored_info_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_stored_info_type_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_stored_info_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_table_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_table_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_table_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_table_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_inspect_content_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_inspect_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_inspect_content_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_inspect_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_column_data_profiles_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_column_data_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_column_data_profiles_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_column_data_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_connections_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_connections_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_deidentify_templates_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_deidentify_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_deidentify_templates_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_deidentify_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_discovery_configs_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_discovery_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_discovery_configs_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_discovery_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_dlp_jobs_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_dlp_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_dlp_jobs_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_dlp_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_file_store_data_profiles_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_file_store_data_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_file_store_data_profiles_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_file_store_data_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_info_types_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_info_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_info_types_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_info_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_inspect_templates_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_inspect_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_inspect_templates_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_inspect_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_job_triggers_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_job_triggers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_job_triggers_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_job_triggers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_project_data_profiles_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_project_data_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_project_data_profiles_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_project_data_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_stored_info_types_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_stored_info_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_stored_info_types_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_stored_info_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_table_data_profiles_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_table_data_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_table_data_profiles_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_table_data_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_redact_image_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_redact_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_redact_image_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_redact_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_reidentify_content_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_reidentify_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_reidentify_content_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_reidentify_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_search_connections_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_search_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_search_connections_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_search_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_connection_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_connection_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_deidentify_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_deidentify_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_deidentify_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_deidentify_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_discovery_config_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_discovery_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_discovery_config_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_discovery_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_inspect_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_inspect_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_inspect_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_inspect_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_stored_info_type_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_stored_info_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_stored_info_type_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_stored_info_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/tests/__init__.py
+++ b/packages/google-cloud-dlp/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/tests/unit/__init__.py
+++ b/packages/google-cloud-dlp/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dlp/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/tests/unit/gapic/dlp_v2/__init__.py
+++ b/packages/google-cloud-dlp/tests/unit/gapic/dlp_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/.flake8
+++ b/packages/google-cloud-dms/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/MANIFEST.in
+++ b/packages/google-cloud-dms/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms/__init__.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms/gapic_version.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/gapic_version.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/__init__.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/__init__.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/client.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/pagers.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/__init__.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/base.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/grpc.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/types/__init__.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/types/clouddms.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/types/clouddms.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/types/clouddms_resources.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/types/clouddms_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_apply_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_apply_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_commit_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_commit_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_convert_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_convert_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_connection_profile_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_mapping_rule_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_mapping_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_mapping_rule_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_mapping_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_private_connection_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_connection_profile_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_mapping_rule_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_mapping_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_mapping_rule_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_mapping_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_private_connection_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_conversion_workspace_revisions_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_conversion_workspace_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_conversion_workspace_revisions_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_conversion_workspace_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_database_entities_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_database_entities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_database_entities_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_database_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_fetch_static_ips_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_fetch_static_ips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_fetch_static_ips_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_fetch_static_ips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_ssh_script_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_ssh_script_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_ssh_script_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_ssh_script_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_tcp_proxy_script_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_tcp_proxy_script_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_tcp_proxy_script_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_tcp_proxy_script_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_connection_profile_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_connection_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_connection_profile_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_conversion_workspace_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_conversion_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_mapping_rule_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_mapping_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_mapping_rule_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_mapping_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_migration_job_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_migration_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_private_connection_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_private_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_private_connection_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_import_mapping_rules_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_import_mapping_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_connection_profiles_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_connection_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_connection_profiles_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_connection_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_conversion_workspaces_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_conversion_workspaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_conversion_workspaces_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_conversion_workspaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_mapping_rules_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_mapping_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_mapping_rules_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_mapping_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_migration_jobs_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_migration_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_migration_jobs_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_migration_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_private_connections_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_private_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_private_connections_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_private_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_promote_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_promote_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_restart_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_restart_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_resume_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_resume_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_rollback_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_rollback_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_search_background_jobs_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_search_background_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_search_background_jobs_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_search_background_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_seed_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_seed_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_start_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_start_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_stop_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_stop_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_connection_profile_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_verify_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_verify_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/tests/__init__.py
+++ b/packages/google-cloud-dms/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/tests/unit/__init__.py
+++ b/packages/google-cloud-dms/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dms/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/tests/unit/gapic/clouddms_v1/__init__.py
+++ b/packages/google-cloud-dms/tests/unit/gapic/clouddms_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/.flake8
+++ b/packages/google-cloud-documentai/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/MANIFEST.in
+++ b/packages/google-cloud-documentai/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai/gapic_version.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/gapic_version.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/client.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/pagers.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/grpc.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/rest.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/rest_base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/barcode.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/barcode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_io.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_io.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_processor_service.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_processor_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_schema.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/evaluation.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/geometry.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/operation_metadata.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/processor.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/processor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/processor_type.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/processor_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/gapic_version.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/client.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/pagers.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/grpc.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/rest.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/rest_base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/client.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/pagers.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/grpc.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/rest.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/rest_base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/barcode.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/barcode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/dataset.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_io.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_io.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_processor_service.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_processor_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_schema.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/evaluation.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/geometry.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/operation_metadata.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/processor.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/processor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/processor_type.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/processor_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_batch_process_documents_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_batch_process_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_create_processor_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_create_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_create_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_create_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_delete_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_delete_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_delete_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_delete_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_deploy_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_deploy_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_disable_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_disable_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_enable_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_enable_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_evaluate_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_evaluate_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_fetch_processor_types_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_fetch_processor_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_fetch_processor_types_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_fetch_processor_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_evaluation_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_evaluation_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_type_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_type_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_version_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_evaluations_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_evaluations_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_types_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_types_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_versions_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_versions_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processors_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processors_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_process_document_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_process_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_process_document_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_process_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_review_document_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_review_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_set_default_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_set_default_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_train_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_train_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_undeploy_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_undeploy_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_batch_process_documents_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_batch_process_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_create_processor_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_create_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_create_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_create_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_delete_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_delete_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_delete_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_delete_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_deploy_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_deploy_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_disable_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_disable_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_enable_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_enable_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_evaluate_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_evaluate_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_fetch_processor_types_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_fetch_processor_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_fetch_processor_types_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_fetch_processor_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_evaluation_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_evaluation_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_type_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_type_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_version_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_import_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_import_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_evaluations_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_evaluations_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_types_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_types_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_versions_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_versions_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processors_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processors_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_process_document_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_process_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_process_document_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_process_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_review_document_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_review_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_set_default_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_set_default_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_train_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_train_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_undeploy_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_undeploy_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_batch_delete_documents_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_batch_delete_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_dataset_schema_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_dataset_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_dataset_schema_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_dataset_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_document_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_document_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_import_documents_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_import_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_list_documents_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_list_documents_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_schema_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_schema_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/tests/__init__.py
+++ b/packages/google-cloud-documentai/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/tests/unit/__init__.py
+++ b/packages/google-cloud-documentai/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-documentai/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/tests/unit/gapic/documentai_v1/__init__.py
+++ b/packages/google-cloud-documentai/tests/unit/gapic/documentai_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/tests/unit/gapic/documentai_v1beta3/__init__.py
+++ b/packages/google-cloud-documentai/tests/unit/gapic/documentai_v1beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/.flake8
+++ b/packages/google-cloud-domains/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/MANIFEST.in
+++ b/packages/google-cloud-domains/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains/gapic_version.py
+++ b/packages/google-cloud-domains/google/cloud/domains/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/gapic_version.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/client.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/pagers.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/base.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/grpc.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/grpc_asyncio.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/rest.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/rest_base.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/types/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/types/domains.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/types/domains.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/gapic_version.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/client.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/pagers.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/base.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/grpc.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/grpc_asyncio.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/rest.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/rest_base.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/types/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/types/domains.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/types/domains.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_contact_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_contact_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_dns_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_dns_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_management_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_management_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_delete_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_delete_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_export_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_export_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_get_registration_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_get_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_get_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_get_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_list_registrations_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_list_registrations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_list_registrations_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_list_registrations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_register_domain_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_register_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_reset_authorization_code_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_reset_authorization_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_reset_authorization_code_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_reset_authorization_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_authorization_code_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_authorization_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_authorization_code_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_authorization_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_register_parameters_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_register_parameters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_register_parameters_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_register_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_transfer_parameters_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_transfer_parameters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_transfer_parameters_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_transfer_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_search_domains_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_search_domains_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_search_domains_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_search_domains_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_transfer_domain_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_transfer_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_update_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_update_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_contact_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_contact_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_dns_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_dns_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_management_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_management_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_delete_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_delete_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_export_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_export_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_get_registration_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_get_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_get_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_get_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_list_registrations_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_list_registrations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_list_registrations_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_list_registrations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_register_domain_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_register_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_reset_authorization_code_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_reset_authorization_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_reset_authorization_code_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_reset_authorization_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_authorization_code_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_authorization_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_authorization_code_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_authorization_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_register_parameters_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_register_parameters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_register_parameters_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_register_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_transfer_parameters_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_transfer_parameters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_transfer_parameters_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_transfer_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_search_domains_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_search_domains_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_search_domains_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_search_domains_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_transfer_domain_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_transfer_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_update_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_update_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/tests/__init__.py
+++ b/packages/google-cloud-domains/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/tests/unit/__init__.py
+++ b/packages/google-cloud-domains/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-domains/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/tests/unit/gapic/domains_v1/__init__.py
+++ b/packages/google-cloud-domains/tests/unit/gapic/domains_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/tests/unit/gapic/domains_v1beta1/__init__.py
+++ b/packages/google-cloud-domains/tests/unit/gapic/domains_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the result of regenerating all packages, but only committing files which have only changed in a single line, and that's a copyright line.
