### PR TITLE
chore: regenerate packages in google-cloud-[e-i], copyright changes only

### DIFF
--- a/packages/google-cloud-edgecontainer/.flake8
+++ b/packages/google-cloud-edgecontainer/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/MANIFEST.in
+++ b/packages/google-cloud-edgecontainer/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer/__init__.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer/gapic_version.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/gapic_version.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/__init__.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/__init__.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/client.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/pagers.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/__init__.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/base.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/grpc.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/grpc_asyncio.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/rest.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/rest_base.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/__init__.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/resources.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/service.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_cluster_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_node_pool_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_vpn_connection_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_vpn_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_cluster_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_node_pool_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_vpn_connection_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_vpn_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_access_token_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_access_token_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_offline_credential_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_offline_credential_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_offline_credential_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_offline_credential_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_cluster_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_cluster_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_machine_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_machine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_machine_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_machine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_node_pool_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_node_pool_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_server_config_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_server_config_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_vpn_connection_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_vpn_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_vpn_connection_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_vpn_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_clusters_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_clusters_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_machines_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_machines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_machines_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_machines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_node_pools_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_node_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_node_pools_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_node_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_vpn_connections_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_vpn_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_vpn_connections_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_vpn_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_update_cluster_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_update_node_pool_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_update_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_upgrade_cluster_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_upgrade_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/tests/__init__.py
+++ b/packages/google-cloud-edgecontainer/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/tests/unit/__init__.py
+++ b/packages/google-cloud-edgecontainer/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-edgecontainer/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/tests/unit/gapic/edgecontainer_v1/__init__.py
+++ b/packages/google-cloud-edgecontainer/tests/unit/gapic/edgecontainer_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/.flake8
+++ b/packages/google-cloud-edgenetwork/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/MANIFEST.in
+++ b/packages/google-cloud-edgenetwork/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork/__init__.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork/gapic_version.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/gapic_version.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/__init__.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/__init__.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/client.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/pagers.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/__init__.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/base.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/grpc.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/grpc_asyncio.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/rest.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/rest_base.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/__init__.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/service.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_interconnect_attachment_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_interconnect_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_network_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_router_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_router_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_subnet_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_interconnect_attachment_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_interconnect_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_network_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_router_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_router_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_subnet_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_interconnect_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_interconnect_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_interconnect_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_interconnect_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_network_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_network_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_router_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_router_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_router_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_router_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_attachment_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_attachment_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_network_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_network_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_router_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_router_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_router_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_router_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_subnet_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_subnet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_subnet_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_zone_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_zone_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_zone_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_initialize_zone_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_initialize_zone_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_initialize_zone_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_initialize_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnect_attachments_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnect_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnect_attachments_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnect_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnects_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnects_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_networks_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_networks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_networks_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_networks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_routers_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_routers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_routers_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_routers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_subnets_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_subnets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_subnets_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_subnets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_zones_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_zones_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_zones_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_zones_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_update_router_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_update_router_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_update_subnet_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_update_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/tests/__init__.py
+++ b/packages/google-cloud-edgenetwork/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/tests/unit/__init__.py
+++ b/packages/google-cloud-edgenetwork/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-edgenetwork/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/tests/unit/gapic/edgenetwork_v1/__init__.py
+++ b/packages/google-cloud-edgenetwork/tests/unit/gapic/edgenetwork_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/.flake8
+++ b/packages/google-cloud-enterpriseknowledgegraph/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/MANIFEST.in
+++ b/packages/google-cloud-enterpriseknowledgegraph/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph/gapic_version.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/gapic_version.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/async_client.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/client.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/pagers.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/base.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/grpc.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/rest.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/rest_base.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/job_state.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/job_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/operation_metadata.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_cancel_entity_reconciliation_job_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_cancel_entity_reconciliation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_cancel_entity_reconciliation_job_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_cancel_entity_reconciliation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_create_entity_reconciliation_job_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_create_entity_reconciliation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_create_entity_reconciliation_job_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_create_entity_reconciliation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_delete_entity_reconciliation_job_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_delete_entity_reconciliation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_delete_entity_reconciliation_job_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_delete_entity_reconciliation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_get_entity_reconciliation_job_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_get_entity_reconciliation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_get_entity_reconciliation_job_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_get_entity_reconciliation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_list_entity_reconciliation_jobs_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_list_entity_reconciliation_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_list_entity_reconciliation_jobs_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_list_entity_reconciliation_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_public_kg_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_public_kg_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_public_kg_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_public_kg_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_public_kg_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_public_kg_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_public_kg_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_public_kg_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/tests/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/tests/unit/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/tests/unit/gapic/enterpriseknowledgegraph_v1/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/tests/unit/gapic/enterpriseknowledgegraph_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/.flake8
+++ b/packages/google-cloud-error-reporting/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/MANIFEST.in
+++ b/packages/google-cloud-error-reporting/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting/gapic_version.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/gapic_version.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/async_client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/grpc.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/rest.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/rest_base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/async_client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/pagers.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/grpc.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/rest.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/rest_base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/async_client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/grpc.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/rest.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/rest_base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/common.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/error_group_service.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/error_group_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/error_stats_service.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/error_stats_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/report_errors_service.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/report_errors_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_get_group_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_get_group_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_update_group_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_update_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_update_group_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_delete_events_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_delete_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_delete_events_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_delete_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_events_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_events_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_group_stats_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_group_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_group_stats_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_group_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_report_errors_service_report_error_event_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_report_errors_service_report_error_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_report_errors_service_report_error_event_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_report_errors_service_report_error_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/tests/__init__.py
+++ b/packages/google-cloud-error-reporting/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/tests/unit/__init__.py
+++ b/packages/google-cloud-error-reporting/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-error-reporting/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/tests/unit/gapic/errorreporting_v1beta1/__init__.py
+++ b/packages/google-cloud-error-reporting/tests/unit/gapic/errorreporting_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/.flake8
+++ b/packages/google-cloud-essential-contacts/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/MANIFEST.in
+++ b/packages/google-cloud-essential-contacts/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts/__init__.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts/gapic_version.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/gapic_version.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/__init__.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/__init__.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/async_client.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/client.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/pagers.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/__init__.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/base.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/grpc.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/rest.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/rest_base.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/__init__.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/enums.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/service.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_compute_contacts_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_compute_contacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_compute_contacts_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_compute_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_create_contact_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_create_contact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_create_contact_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_create_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_delete_contact_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_delete_contact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_delete_contact_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_delete_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_get_contact_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_get_contact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_get_contact_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_get_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_list_contacts_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_list_contacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_list_contacts_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_list_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_send_test_message_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_send_test_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_send_test_message_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_send_test_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_update_contact_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_update_contact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_update_contact_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_update_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/tests/__init__.py
+++ b/packages/google-cloud-essential-contacts/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/tests/unit/__init__.py
+++ b/packages/google-cloud-essential-contacts/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-essential-contacts/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/tests/unit/gapic/essential_contacts_v1/__init__.py
+++ b/packages/google-cloud-essential-contacts/tests/unit/gapic/essential_contacts_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/.flake8
+++ b/packages/google-cloud-eventarc-publishing/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/MANIFEST.in
+++ b/packages/google-cloud-eventarc-publishing/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing/gapic_version.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/gapic_version.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/async_client.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/client.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/base.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/grpc.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/grpc_asyncio.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/rest.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/rest_base.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/cloud_event.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/cloud_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/publisher.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/publisher.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_async.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_channel_connection_events_async.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_channel_connection_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_channel_connection_events_sync.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_channel_connection_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_events_async.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_events_sync.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_sync.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/tests/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/tests/unit/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/tests/unit/gapic/eventarc_publishing_v1/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/tests/unit/gapic/eventarc_publishing_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/.flake8
+++ b/packages/google-cloud-eventarc/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/MANIFEST.in
+++ b/packages/google-cloud-eventarc/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc/__init__.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc/gapic_version.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/gapic_version.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/__init__.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/__init__.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/pagers.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/__init__.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/base.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc_asyncio.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest_base.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/__init__.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/channel.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/channel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/channel_connection.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/channel_connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/discovery.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/discovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/enrollment.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/enrollment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/eventarc.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/eventarc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/google_api_source.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/google_api_source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/google_channel_config.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/google_channel_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/logging_config.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/logging_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/message_bus.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/message_bus.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/network_config.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/network_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/pipeline.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/pipeline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/trigger.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/trigger.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_connection_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_enrollment_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_google_api_source_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_google_api_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_message_bus_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_message_bus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_pipeline_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_trigger_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_connection_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_enrollment_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_google_api_source_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_google_api_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_message_bus_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_message_bus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_pipeline_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_trigger_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_enrollment_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_enrollment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_enrollment_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_api_source_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_api_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_api_source_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_api_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_message_bus_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_message_bus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_message_bus_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_message_bus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_pipeline_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_pipeline_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_pipeline_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_enrollments_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_enrollments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_enrollments_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_enrollments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_google_api_sources_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_google_api_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_google_api_sources_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_google_api_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_bus_enrollments_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_bus_enrollments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_bus_enrollments_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_bus_enrollments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_buses_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_buses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_buses_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_buses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_pipelines_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_pipelines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_pipelines_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_pipelines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_channel_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_enrollment_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_api_source_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_api_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_message_bus_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_message_bus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_pipeline_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_trigger_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/tests/__init__.py
+++ b/packages/google-cloud-eventarc/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/tests/unit/__init__.py
+++ b/packages/google-cloud-eventarc/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-eventarc/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/tests/unit/gapic/eventarc_v1/__init__.py
+++ b/packages/google-cloud-eventarc/tests/unit/gapic/eventarc_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/.flake8
+++ b/packages/google-cloud-filestore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/MANIFEST.in
+++ b/packages/google-cloud-filestore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore/__init__.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore/gapic_version.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/gapic_version.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/__init__.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/__init__.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/client.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/pagers.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/__init__.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/base.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/grpc.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/rest.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/rest_base.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/types/__init__.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/types/cloud_filestore_service.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/types/cloud_filestore_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_backup_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_snapshot_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_backup_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_snapshot_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_backup_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_backup_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_instance_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_snapshot_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_snapshot_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_backups_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_backups_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_instances_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_instances_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_snapshots_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_snapshots_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_promote_replica_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_promote_replica_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_restore_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_restore_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_revert_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_revert_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_backup_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_snapshot_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/tests/__init__.py
+++ b/packages/google-cloud-filestore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/tests/unit/__init__.py
+++ b/packages/google-cloud-filestore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-filestore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/tests/unit/gapic/filestore_v1/__init__.py
+++ b/packages/google-cloud-filestore/tests/unit/gapic/filestore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/.flake8
+++ b/packages/google-cloud-financialservices/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/MANIFEST.in
+++ b/packages/google-cloud-financialservices/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices/__init__.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices/gapic_version.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/gapic_version.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/__init__.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/__init__.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/client.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/pagers.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/__init__.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/base.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/grpc.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/grpc_asyncio.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/rest.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/rest_base.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/__init__.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/backtest_result.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/backtest_result.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/bigquery_destination.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/bigquery_destination.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/dataset.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/engine_config.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/engine_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/engine_version.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/engine_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/instance.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/line_of_business.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/line_of_business.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/model.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/prediction_result.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/prediction_result.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/service.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_backtest_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_backtest_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_dataset_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_engine_config_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_engine_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_instance_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_model_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_prediction_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_prediction_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_backtest_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_backtest_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_dataset_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_engine_config_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_engine_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_instance_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_model_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_prediction_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_prediction_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_backtest_result_metadata_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_backtest_result_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_engine_config_metadata_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_engine_config_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_model_metadata_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_model_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_prediction_result_metadata_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_prediction_result_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_registered_parties_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_registered_parties_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_backtest_result_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_backtest_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_backtest_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_backtest_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_dataset_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_dataset_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_config_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_config_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_version_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_version_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_instance_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_instance_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_model_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_model_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_prediction_result_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_prediction_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_prediction_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_prediction_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_import_registered_parties_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_import_registered_parties_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_backtest_results_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_backtest_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_backtest_results_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_backtest_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_datasets_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_datasets_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_configs_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_configs_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_versions_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_versions_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_instances_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_instances_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_models_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_models_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_prediction_results_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_prediction_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_prediction_results_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_prediction_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_backtest_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_backtest_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_dataset_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_engine_config_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_engine_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_instance_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_model_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_prediction_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_prediction_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/tests/__init__.py
+++ b/packages/google-cloud-financialservices/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/tests/unit/__init__.py
+++ b/packages/google-cloud-financialservices/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-financialservices/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/tests/unit/gapic/financialservices_v1/__init__.py
+++ b/packages/google-cloud-financialservices/tests/unit/gapic/financialservices_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/.flake8
+++ b/packages/google-cloud-firestore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/MANIFEST.in
+++ b/packages/google-cloud-firestore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/client.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/pagers.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/base.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/grpc.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/rest.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/rest_base.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/backup.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/backup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/database.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/field.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/field.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/firestore_admin.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/firestore_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/index.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/index.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/location.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/operation.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/operation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/realtime_updates.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/realtime_updates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/schedule.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/schedule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/snapshot.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/snapshot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/user_creds.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/user_creds.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_bundle/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_bundle/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_bundle/services/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_bundle/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_bundle/types/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_bundle/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_bundle/types/bundle.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_bundle/types/bundle.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/async_client.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/client.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/pagers.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/base.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/grpc.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/rest.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/rest_base.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/aggregation_result.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/aggregation_result.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/bloom_filter.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/bloom_filter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/common.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/document.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/explain_stats.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/explain_stats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/firestore.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/firestore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/pipeline.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/pipeline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/query.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/query_profile.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/query_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/write.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/write.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_bulk_delete_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_bulk_delete_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_clone_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_clone_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_index_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_export_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_export_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_import_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_import_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_restore_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_restore_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_field_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_get_documents_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_get_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_get_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_get_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_write_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_write_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_write_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_write_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_begin_transaction_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_begin_transaction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_begin_transaction_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_begin_transaction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_commit_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_commit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_commit_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_commit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_create_document_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_create_document_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_delete_document_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_delete_document_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_execute_pipeline_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_execute_pipeline_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_execute_pipeline_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_execute_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_get_document_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_get_document_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_collection_ids_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_collection_ids_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_collection_ids_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_collection_ids_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_documents_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_listen_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_listen_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_listen_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_listen_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_partition_query_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_partition_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_partition_query_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_partition_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_rollback_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_rollback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_rollback_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_rollback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_aggregation_query_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_aggregation_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_aggregation_query_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_aggregation_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_query_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_query_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_update_document_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_update_document_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_write_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_write_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_write_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_write_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/__init__.py
+++ b/packages/google-cloud-firestore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/unit/__init__.py
+++ b/packages/google-cloud-firestore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-firestore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/unit/gapic/firestore_admin_v1/__init__.py
+++ b/packages/google-cloud-firestore/tests/unit/gapic/firestore_admin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/unit/gapic/firestore_bundle/__init__.py
+++ b/packages/google-cloud-firestore/tests/unit/gapic/firestore_bundle/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/unit/gapic/firestore_v1/__init__.py
+++ b/packages/google-cloud-firestore/tests/unit/gapic/firestore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/.flake8
+++ b/packages/google-cloud-functions/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/MANIFEST.in
+++ b/packages/google-cloud-functions/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions/gapic_version.py
+++ b/packages/google-cloud-functions/google/cloud/functions/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/gapic_version.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/client.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/pagers.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/base.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/grpc.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/rest.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/rest_base.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/types/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/types/functions.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/types/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/types/operations.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/gapic_version.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/client.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/pagers.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/base.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/grpc.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/rest.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/rest_base.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/types/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/types/functions.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/types/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_call_function_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_call_function_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_call_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_call_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_create_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_create_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_delete_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_delete_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_download_url_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_download_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_download_url_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_download_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_upload_url_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_upload_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_upload_url_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_upload_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_function_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_function_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_iam_policy_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_list_functions_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_list_functions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_list_functions_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_list_functions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_set_iam_policy_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_update_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_update_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_create_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_create_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_delete_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_delete_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_download_url_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_download_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_download_url_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_download_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_upload_url_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_upload_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_upload_url_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_upload_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_get_function_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_get_function_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_get_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_get_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_functions_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_functions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_functions_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_functions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_runtimes_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_runtimes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_runtimes_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_runtimes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_update_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_update_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/tests/__init__.py
+++ b/packages/google-cloud-functions/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/tests/unit/__init__.py
+++ b/packages/google-cloud-functions/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-functions/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/tests/unit/gapic/functions_v1/__init__.py
+++ b/packages/google-cloud-functions/tests/unit/gapic/functions_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/tests/unit/gapic/functions_v2/__init__.py
+++ b/packages/google-cloud-functions/tests/unit/gapic/functions_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/.flake8
+++ b/packages/google-cloud-gdchardwaremanagement/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/MANIFEST.in
+++ b/packages/google-cloud-gdchardwaremanagement/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement/gapic_version.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/gapic_version.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/client.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/pagers.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/base.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/grpc.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/rest.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/rest_base.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/types/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/types/service.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_cancel_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_cancel_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_comment_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_hardware_group_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_hardware_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_hardware_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_hardware_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_site_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_zone_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_hardware_group_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_hardware_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_hardware_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_hardware_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_site_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_zone_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_change_log_entry_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_change_log_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_change_log_entry_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_change_log_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_comment_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_comment_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_group_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_group_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_order_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_order_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_site_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_site_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_site_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_sku_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_sku_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_sku_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_sku_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_zone_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_zone_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_zone_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_change_log_entries_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_change_log_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_change_log_entries_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_change_log_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_comments_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_comments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_comments_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_groups_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_groups_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_orders_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_orders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_orders_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_orders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_sites_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_sites_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_sites_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_skus_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_skus_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_zones_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_zones_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_zones_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_zones_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_record_action_on_comment_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_record_action_on_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_record_action_on_comment_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_record_action_on_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_request_order_date_change_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_request_order_date_change_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_signal_zone_state_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_signal_zone_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_submit_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_submit_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_hardware_group_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_hardware_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_hardware_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_hardware_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_site_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_zone_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/tests/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/tests/unit/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/tests/unit/gapic/gdchardwaremanagement_v1alpha/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/tests/unit/gapic/gdchardwaremanagement_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/.flake8
+++ b/packages/google-cloud-geminidataanalytics/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/MANIFEST.in
+++ b/packages/google-cloud-geminidataanalytics/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/async_client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/context.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/conversation.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/credentials.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/credentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_agent_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_agent_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_analytics_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_analytics_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_chat_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_chat_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/datasource.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/datasource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/async_client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/agent_context.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/agent_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/context.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/conversation.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/credentials.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/credentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_agent_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_agent_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_analytics_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_analytics_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_chat_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_chat_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/datasource.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/datasource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/async_client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/agent_context.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/agent_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/context.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/conversation.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/credentials.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/credentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_agent_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_agent_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_analytics_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_analytics_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_chat_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_chat_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/datasource.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/datasource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_data_agent_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_data_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_accessible_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_accessible_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_accessible_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_accessible_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_set_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_chat_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_chat_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_chat_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_chat_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_create_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_create_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_delete_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_delete_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_get_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_get_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_conversations_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_conversations_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_messages_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_messages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_messages_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_messages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_data_agent_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_data_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_accessible_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_accessible_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_accessible_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_accessible_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_set_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_chat_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_chat_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_chat_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_chat_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_create_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_create_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_delete_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_delete_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_get_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_get_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_conversations_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_conversations_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_messages_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_messages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_messages_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_messages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_query_data_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_query_data_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_query_data_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_query_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_data_agent_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_data_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_accessible_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_accessible_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_accessible_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_accessible_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_set_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_chat_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_chat_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_chat_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_chat_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_create_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_create_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_delete_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_delete_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_get_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_get_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_conversations_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_conversations_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_messages_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_messages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_messages_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_messages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_query_data_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_query_data_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_query_data_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_query_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/unit/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1alpha/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1beta/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/.flake8
+++ b/packages/google-cloud-gke-backup/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/MANIFEST.in
+++ b/packages/google-cloud-gke-backup/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup/__init__.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup/gapic_version.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/gapic_version.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/__init__.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/__init__.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/client.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/pagers.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/__init__.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/base.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/grpc.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/rest.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/rest_base.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/__init__.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_channel.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_channel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_plan.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_plan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_plan_binding.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_plan_binding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/common.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/gkebackup.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/gkebackup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_channel.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_channel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_plan.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_plan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_plan_binding.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_plan_binding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/volume.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/volume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_channel_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_index_download_url_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_index_download_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_index_download_url_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_index_download_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_binding_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_binding_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_channel_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_binding_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_binding_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_backup_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_backup_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_restore_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_restore_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_restore_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_restore_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_channels_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_channels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_channels_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_channels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plan_bindings_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plan_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plan_bindings_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plan_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plans_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plans_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plans_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plans_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backups_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backups_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_channels_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_channels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_channels_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_channels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plan_bindings_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plan_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plan_bindings_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plan_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plans_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plans_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plans_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plans_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restores_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restores_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_backups_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_backups_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_restores_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_restores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_restores_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_restores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/tests/__init__.py
+++ b/packages/google-cloud-gke-backup/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/tests/unit/__init__.py
+++ b/packages/google-cloud-gke-backup/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gke-backup/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/tests/unit/gapic/gke_backup_v1/__init__.py
+++ b/packages/google-cloud-gke-backup/tests/unit/gapic/gke_backup_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/.flake8
+++ b/packages/google-cloud-gke-connect-gateway/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/MANIFEST.in
+++ b/packages/google-cloud-gke-connect-gateway/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway/gapic_version.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/gapic_version.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/client.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/base.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/rest.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/rest_base.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/types/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/types/control.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/gapic_version.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/client.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/base.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/rest.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/rest_base.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/types/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/types/control.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/samples/generated_samples/connectgateway_v1_generated_gateway_control_generate_credentials_sync.py
+++ b/packages/google-cloud-gke-connect-gateway/samples/generated_samples/connectgateway_v1_generated_gateway_control_generate_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/samples/generated_samples/connectgateway_v1beta1_generated_gateway_control_generate_credentials_sync.py
+++ b/packages/google-cloud-gke-connect-gateway/samples/generated_samples/connectgateway_v1beta1_generated_gateway_control_generate_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/tests/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/tests/unit/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/gateway_v1/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/gateway_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/gateway_v1beta1/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/gateway_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/.flake8
+++ b/packages/google-cloud-gke-hub/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/MANIFEST.in
+++ b/packages/google-cloud-gke-hub/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub/gapic_version.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/gapic_version.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/client.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/pagers.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/base.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/grpc.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/rest.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/rest_base.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/feature.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/feature.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/fleet.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/fleet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/membership.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/membership.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/service.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/gapic_version.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/client.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/pagers.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/base.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/grpc.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/rest.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/rest_base.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/types/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/types/membership.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/types/membership.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_feature_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_feature_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_fleet_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_fleet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_namespace_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_feature_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_feature_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_fleet_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_fleet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_namespace_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_connect_manifest_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_connect_manifest_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_connect_manifest_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_connect_manifest_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_membership_rbac_role_binding_yaml_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_membership_rbac_role_binding_yaml_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_membership_rbac_role_binding_yaml_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_membership_rbac_role_binding_yaml_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_feature_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_feature_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_feature_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_feature_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_fleet_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_fleet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_fleet_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_fleet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_binding_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_rbac_role_binding_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_rbac_role_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_namespace_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_namespace_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_rbac_role_binding_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_rbac_role_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_bound_memberships_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_bound_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_bound_memberships_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_bound_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_features_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_features_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_features_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_features_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_fleets_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_fleets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_fleets_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_fleets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_bindings_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_bindings_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_rbac_role_bindings_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_rbac_role_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_rbac_role_bindings_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_rbac_role_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_memberships_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_memberships_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_permitted_scopes_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_permitted_scopes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_permitted_scopes_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_permitted_scopes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_namespaces_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_namespaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_namespaces_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_namespaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_rbac_role_bindings_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_rbac_role_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_rbac_role_bindings_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_rbac_role_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scopes_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scopes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scopes_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scopes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_feature_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_feature_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_fleet_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_fleet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_namespace_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_create_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_create_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_delete_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_delete_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_connect_manifest_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_connect_manifest_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_connect_manifest_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_connect_manifest_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_exclusivity_manifest_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_exclusivity_manifest_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_exclusivity_manifest_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_exclusivity_manifest_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_get_membership_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_get_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_get_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_get_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_list_memberships_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_list_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_list_memberships_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_list_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_update_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_update_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_validate_exclusivity_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_validate_exclusivity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_validate_exclusivity_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_validate_exclusivity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/tests/__init__.py
+++ b/packages/google-cloud-gke-hub/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/tests/unit/__init__.py
+++ b/packages/google-cloud-gke-hub/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gke-hub/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/tests/unit/gapic/gkehub_v1/__init__.py
+++ b/packages/google-cloud-gke-hub/tests/unit/gapic/gkehub_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/tests/unit/gapic/gkehub_v1beta1/__init__.py
+++ b/packages/google-cloud-gke-hub/tests/unit/gapic/gkehub_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/.flake8
+++ b/packages/google-cloud-gke-multicloud/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/MANIFEST.in
+++ b/packages/google-cloud-gke-multicloud/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud/gapic_version.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/gapic_version.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/client.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/pagers.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/grpc.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/rest.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/rest_base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/client.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/pagers.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/grpc.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/rest.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/rest_base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/client.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/pagers.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/grpc.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/rest.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/rest_base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/attached_resources.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/attached_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/attached_service.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/attached_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/aws_resources.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/aws_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/aws_service.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/aws_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/azure_resources.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/azure_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/azure_service.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/azure_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/common_resources.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/common_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_create_attached_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_create_attached_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_delete_attached_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_delete_attached_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_agent_token_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_agent_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_agent_token_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_agent_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_install_manifest_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_install_manifest_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_install_manifest_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_install_manifest_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_cluster_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_server_config_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_server_config_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_import_attached_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_import_attached_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_list_attached_clusters_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_list_attached_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_list_attached_clusters_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_list_attached_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_update_attached_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_update_attached_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_create_aws_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_create_aws_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_create_aws_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_create_aws_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_delete_aws_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_delete_aws_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_delete_aws_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_delete_aws_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_access_token_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_access_token_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_cluster_agent_token_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_cluster_agent_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_cluster_agent_token_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_cluster_agent_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_cluster_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_json_web_keys_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_json_web_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_json_web_keys_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_json_web_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_node_pool_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_open_id_config_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_open_id_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_open_id_config_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_open_id_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_server_config_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_server_config_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_clusters_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_clusters_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_node_pools_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_node_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_node_pools_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_node_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_rollback_aws_node_pool_update_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_rollback_aws_node_pool_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_update_aws_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_update_aws_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_update_aws_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_update_aws_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_client_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_client_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_access_token_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_access_token_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_cluster_agent_token_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_cluster_agent_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_cluster_agent_token_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_cluster_agent_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_client_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_client_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_client_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_cluster_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_json_web_keys_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_json_web_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_json_web_keys_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_json_web_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_node_pool_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_open_id_config_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_open_id_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_open_id_config_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_open_id_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_server_config_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_server_config_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clients_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clients_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clients_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clients_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clusters_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clusters_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_node_pools_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_node_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_node_pools_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_node_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_update_azure_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_update_azure_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_update_azure_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_update_azure_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/tests/__init__.py
+++ b/packages/google-cloud-gke-multicloud/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/tests/unit/__init__.py
+++ b/packages/google-cloud-gke-multicloud/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gke-multicloud/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/tests/unit/gapic/gke_multicloud_v1/__init__.py
+++ b/packages/google-cloud-gke-multicloud/tests/unit/gapic/gke_multicloud_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/.flake8
+++ b/packages/google-cloud-gkerecommender/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/MANIFEST.in
+++ b/packages/google-cloud-gkerecommender/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender/__init__.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender/gapic_version.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/gapic_version.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/__init__.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/__init__.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/async_client.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/client.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/pagers.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/__init__.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/base.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/grpc.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/rest.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/rest_base.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/types/__init__.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/types/gkerecommender.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/types/gkerecommender.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_benchmarking_data_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_benchmarking_data_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_benchmarking_data_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_benchmarking_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_server_versions_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_server_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_server_versions_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_server_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_servers_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_servers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_servers_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_servers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_models_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_models_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_profiles_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_profiles_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_generate_optimized_manifest_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_generate_optimized_manifest_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_generate_optimized_manifest_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_generate_optimized_manifest_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/tests/__init__.py
+++ b/packages/google-cloud-gkerecommender/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/tests/unit/__init__.py
+++ b/packages/google-cloud-gkerecommender/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gkerecommender/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/tests/unit/gapic/gkerecommender_v1/__init__.py
+++ b/packages/google-cloud-gkerecommender/tests/unit/gapic/gkerecommender_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/.flake8
+++ b/packages/google-cloud-gsuiteaddons/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/MANIFEST.in
+++ b/packages/google-cloud-gsuiteaddons/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons/gapic_version.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/gapic_version.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/async_client.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/client.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/pagers.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/base.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/grpc.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/rest.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/rest_base.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/types/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/types/gsuiteaddons.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/types/gsuiteaddons.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_create_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_create_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_delete_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_delete_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_delete_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_delete_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_authorization_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_authorization_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_authorization_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_authorization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_install_status_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_install_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_install_status_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_install_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_install_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_install_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_install_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_install_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_list_deployments_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_list_deployments_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_replace_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_replace_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_replace_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_replace_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_uninstall_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_uninstall_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_uninstall_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_uninstall_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/tests/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/tests/unit/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/tests/unit/gapic/gsuiteaddons_v1/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/tests/unit/gapic/gsuiteaddons_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/.flake8
+++ b/packages/google-cloud-hypercomputecluster/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/MANIFEST.in
+++ b/packages/google-cloud-hypercomputecluster/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster/gapic_version.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/gapic_version.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/client.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/pagers.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/base.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/grpc.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/grpc_asyncio.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/rest.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/rest_base.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/hypercompute_cluster.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/hypercompute_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/operation_metadata.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/gapic_version.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/client.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/pagers.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/base.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/grpc.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/grpc_asyncio.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/rest.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/rest_base.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/hypercompute_cluster.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/hypercompute_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/operation_metadata.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_create_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_delete_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_get_cluster_async.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_get_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_list_clusters_async.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_list_clusters_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_update_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_create_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_delete_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_get_cluster_async.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_get_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_list_clusters_async.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_list_clusters_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_update_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/tests/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/tests/unit/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/tests/unit/gapic/hypercomputecluster_v1/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/tests/unit/gapic/hypercomputecluster_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/tests/unit/gapic/hypercomputecluster_v1beta/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/tests/unit/gapic/hypercomputecluster_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/.flake8
+++ b/packages/google-cloud-iam-logging/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/MANIFEST.in
+++ b/packages/google-cloud-iam-logging/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging/__init__.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging/gapic_version.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/gapic_version.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/services/__init__.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/types/__init__.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/types/audit_data.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/types/audit_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/tests/__init__.py
+++ b/packages/google-cloud-iam-logging/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/tests/unit/__init__.py
+++ b/packages/google-cloud-iam-logging/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-iam-logging/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/tests/unit/gapic/iam_logging_v1/__init__.py
+++ b/packages/google-cloud-iam-logging/tests/unit/gapic/iam_logging_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/.flake8
+++ b/packages/google-cloud-iam/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/MANIFEST.in
+++ b/packages/google-cloud-iam/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/async_client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/audit_data.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/audit_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/iam.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/iam.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/async_client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/common.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/iamcredentials.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/iamcredentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/types/deny.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/types/deny.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/types/policy.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/types/policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/types/deny.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/types/deny.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/types/policy.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/types/policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/operation_metadata.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/policy_binding_resources.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/policy_binding_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/policy_bindings_service.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/policy_bindings_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/principal_access_boundary_policies_service.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/principal_access_boundary_policies_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/principal_access_boundary_policy_resources.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/principal_access_boundary_policy_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/access_policies_service.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/access_policies_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/access_policy_resources.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/access_policy_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/operation_metadata.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/policy_binding_resources.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/policy_binding_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/policy_bindings_service.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/policy_bindings_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/principal_access_boundary_policies_service.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/principal_access_boundary_policies_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/principal_access_boundary_policy_resources.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/principal_access_boundary_policy_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_role_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_role_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_role_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_role_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_role_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_role_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_iam_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_iam_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_role_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_role_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_role_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_lint_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_lint_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_lint_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_lint_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_roles_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_roles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_roles_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_roles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_account_keys_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_account_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_account_keys_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_account_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_accounts_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_accounts_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_patch_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_patch_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_patch_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_patch_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_auditable_services_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_auditable_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_auditable_services_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_auditable_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_grantable_roles_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_grantable_roles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_grantable_roles_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_grantable_roles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_testable_permissions_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_testable_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_testable_permissions_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_testable_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_set_iam_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_set_iam_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_blob_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_blob_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_blob_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_blob_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_jwt_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_jwt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_jwt_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_jwt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_test_iam_permissions_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_test_iam_permissions_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_role_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_role_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_role_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_role_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_role_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_role_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_upload_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_upload_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_upload_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_upload_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_create_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_create_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_delete_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_delete_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_get_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_get_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_get_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_get_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_list_policies_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_list_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_list_policies_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_list_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_update_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_update_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_create_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_create_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_delete_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_delete_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_get_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_get_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_get_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_get_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_list_policies_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_list_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_list_policies_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_list_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_update_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_update_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_create_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_create_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_delete_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_delete_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_get_policy_binding_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_get_policy_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_get_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_get_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_list_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_list_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_list_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_list_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_search_target_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_search_target_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_search_target_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_search_target_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_update_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_update_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_create_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_create_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_delete_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_delete_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_update_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_update_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_create_access_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_create_access_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_delete_access_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_delete_access_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_get_access_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_get_access_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_get_access_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_get_access_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_list_access_policies_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_list_access_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_list_access_policies_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_list_access_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_search_access_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_search_access_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_search_access_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_search_access_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_update_access_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_update_access_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_create_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_create_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_delete_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_delete_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_get_policy_binding_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_get_policy_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_get_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_get_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_list_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_list_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_list_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_list_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_search_target_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_search_target_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_search_target_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_search_target_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_update_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_update_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_create_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_create_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_delete_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_delete_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_update_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_update_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/__init__.py
+++ b/packages/google-cloud-iam/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_admin_v1/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_admin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_credentials_v1/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_credentials_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_v2/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_v2beta/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_v3/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_v3beta/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_v3beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/.flake8
+++ b/packages/google-cloud-iamconnectorcredentials/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/MANIFEST.in
+++ b/packages/google-cloud-iamconnectorcredentials/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials/gapic_version.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/gapic_version.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/client.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/base.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/grpc.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/rest.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/rest_base.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/types/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/types/connector_credentials.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/types/connector_credentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_finalize_credentials_async.py
+++ b/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_finalize_credentials_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_finalize_credentials_sync.py
+++ b/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_finalize_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_retrieve_credentials_sync.py
+++ b/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_retrieve_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/tests/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/tests/unit/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/tests/unit/gapic/iamconnectorcredentials_v1alpha/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/tests/unit/gapic/iamconnectorcredentials_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/.flake8
+++ b/packages/google-cloud-iap/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/MANIFEST.in
+++ b/packages/google-cloud-iap/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap/gapic_version.py
+++ b/packages/google-cloud-iap/google/cloud/iap/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/gapic_version.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/async_client.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/client.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/pagers.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/base.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/grpc.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/rest.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/rest_base.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/async_client.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/client.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/pagers.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/base.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/grpc.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/rest.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/rest_base.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/types/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/types/service.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_create_tunnel_dest_group_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_create_tunnel_dest_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_create_tunnel_dest_group_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_create_tunnel_dest_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_delete_tunnel_dest_group_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_delete_tunnel_dest_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_delete_tunnel_dest_group_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_delete_tunnel_dest_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iam_policy_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iap_settings_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iap_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iap_settings_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iap_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_tunnel_dest_group_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_tunnel_dest_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_tunnel_dest_group_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_tunnel_dest_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_list_tunnel_dest_groups_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_list_tunnel_dest_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_list_tunnel_dest_groups_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_list_tunnel_dest_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_set_iam_policy_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_iap_settings_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_iap_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_iap_settings_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_iap_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_tunnel_dest_group_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_tunnel_dest_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_tunnel_dest_group_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_tunnel_dest_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_validate_iap_attribute_expression_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_validate_iap_attribute_expression_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_validate_iap_attribute_expression_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_validate_iap_attribute_expression_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_brand_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_brand_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_brand_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_brand_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_identity_aware_proxy_client_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_identity_aware_proxy_client_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_identity_aware_proxy_client_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_identity_aware_proxy_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_delete_identity_aware_proxy_client_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_delete_identity_aware_proxy_client_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_delete_identity_aware_proxy_client_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_delete_identity_aware_proxy_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_brand_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_brand_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_brand_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_brand_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_identity_aware_proxy_client_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_identity_aware_proxy_client_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_identity_aware_proxy_client_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_identity_aware_proxy_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_brands_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_brands_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_brands_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_brands_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_identity_aware_proxy_clients_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_identity_aware_proxy_clients_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_identity_aware_proxy_clients_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_identity_aware_proxy_clients_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_reset_identity_aware_proxy_client_secret_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_reset_identity_aware_proxy_client_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_reset_identity_aware_proxy_client_secret_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_reset_identity_aware_proxy_client_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/tests/__init__.py
+++ b/packages/google-cloud-iap/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/tests/unit/__init__.py
+++ b/packages/google-cloud-iap/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-iap/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/tests/unit/gapic/iap_v1/__init__.py
+++ b/packages/google-cloud-iap/tests/unit/gapic/iap_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/.flake8
+++ b/packages/google-cloud-ids/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/MANIFEST.in
+++ b/packages/google-cloud-ids/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids/__init__.py
+++ b/packages/google-cloud-ids/google/cloud/ids/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids/gapic_version.py
+++ b/packages/google-cloud-ids/google/cloud/ids/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/gapic_version.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/__init__.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/__init__.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/client.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/pagers.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/__init__.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/base.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/grpc.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/rest.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/rest_base.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/types/__init__.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/types/ids.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/types/ids.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_create_endpoint_sync.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_create_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_delete_endpoint_sync.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_delete_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_get_endpoint_async.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_get_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_get_endpoint_sync.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_get_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_list_endpoints_async.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_list_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_list_endpoints_sync.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_list_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/tests/__init__.py
+++ b/packages/google-cloud-ids/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/tests/unit/__init__.py
+++ b/packages/google-cloud-ids/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-ids/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/tests/unit/gapic/ids_v1/__init__.py
+++ b/packages/google-cloud-ids/tests/unit/gapic/ids_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the result of regenerating all packages, but only committing files which have only changed in a single line, and that's a copyright line.
