### PR TITLE
chore: regenerate packages in google-cloud-[j-n], copyright changes only

### DIFF
--- a/packages/google-cloud-kms-inventory/.flake8
+++ b/packages/google-cloud-kms-inventory/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/MANIFEST.in
+++ b/packages/google-cloud-kms-inventory/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory/gapic_version.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/gapic_version.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/async_client.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/client.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/pagers.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/base.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/grpc.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/rest.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/rest_base.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/async_client.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/client.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/pagers.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/base.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/grpc.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/rest.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/rest_base.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/key_dashboard_service.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/key_dashboard_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/key_tracking_service.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/key_tracking_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_dashboard_service_list_crypto_keys_async.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_dashboard_service_list_crypto_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_dashboard_service_list_crypto_keys_sync.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_dashboard_service_list_crypto_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_get_protected_resources_summary_async.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_get_protected_resources_summary_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_get_protected_resources_summary_sync.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_get_protected_resources_summary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_search_protected_resources_async.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_search_protected_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_search_protected_resources_sync.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_search_protected_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/tests/__init__.py
+++ b/packages/google-cloud-kms-inventory/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/tests/unit/__init__.py
+++ b/packages/google-cloud-kms-inventory/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-kms-inventory/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/tests/unit/gapic/kms_inventory_v1/__init__.py
+++ b/packages/google-cloud-kms-inventory/tests/unit/gapic/kms_inventory_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/.flake8
+++ b/packages/google-cloud-kms/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/MANIFEST.in
+++ b/packages/google-cloud-kms/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms/gapic_version.py
+++ b/packages/google-cloud-kms/google/cloud/kms/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/gapic_version.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/pagers.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/grpc.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/rest.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/rest_base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/async_client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/grpc.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/rest.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/rest_base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/async_client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/pagers.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/grpc.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/rest.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/rest_base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/pagers.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/grpc.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/rest.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/rest_base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/pagers.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/grpc.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/rest.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/rest_base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/autokey.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/autokey.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/autokey_admin.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/autokey_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/ekm_service.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/ekm_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/hsm_management.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/hsm_management.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/resources.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/service.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_get_autokey_config_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_get_autokey_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_get_autokey_config_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_get_autokey_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_show_effective_autokey_config_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_show_effective_autokey_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_show_effective_autokey_config_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_show_effective_autokey_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_update_autokey_config_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_update_autokey_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_update_autokey_config_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_update_autokey_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_create_key_handle_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_create_key_handle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_get_key_handle_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_get_key_handle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_get_key_handle_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_get_key_handle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_list_key_handles_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_list_key_handles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_list_key_handles_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_list_key_handles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_create_ekm_connection_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_create_ekm_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_create_ekm_connection_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_create_ekm_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_config_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_config_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_connection_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_connection_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_list_ekm_connections_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_list_ekm_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_list_ekm_connections_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_list_ekm_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_config_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_config_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_connection_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_connection_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_verify_connectivity_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_verify_connectivity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_verify_connectivity_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_verify_connectivity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_approve_single_tenant_hsm_instance_proposal_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_approve_single_tenant_hsm_instance_proposal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_approve_single_tenant_hsm_instance_proposal_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_approve_single_tenant_hsm_instance_proposal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_create_single_tenant_hsm_instance_proposal_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_create_single_tenant_hsm_instance_proposal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_create_single_tenant_hsm_instance_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_create_single_tenant_hsm_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_delete_single_tenant_hsm_instance_proposal_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_delete_single_tenant_hsm_instance_proposal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_delete_single_tenant_hsm_instance_proposal_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_delete_single_tenant_hsm_instance_proposal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_execute_single_tenant_hsm_instance_proposal_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_execute_single_tenant_hsm_instance_proposal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_proposal_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_proposal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_proposal_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_proposal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instance_proposals_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instance_proposals_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instance_proposals_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instance_proposals_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instances_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instances_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_decrypt_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_decrypt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_decrypt_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_decrypt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_sign_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_sign_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_sign_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_sign_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_import_job_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_import_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_import_job_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_key_ring_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_key_ring_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_key_ring_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_key_ring_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decapsulate_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decapsulate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decapsulate_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decapsulate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decrypt_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decrypt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decrypt_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decrypt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_delete_crypto_key_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_delete_crypto_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_delete_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_delete_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_destroy_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_destroy_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_destroy_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_destroy_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_encrypt_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_encrypt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_encrypt_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_encrypt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_generate_random_bytes_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_generate_random_bytes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_generate_random_bytes_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_generate_random_bytes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_import_job_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_import_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_import_job_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_key_ring_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_key_ring_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_key_ring_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_key_ring_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_public_key_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_public_key_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_retired_resource_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_retired_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_retired_resource_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_retired_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_import_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_import_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_import_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_import_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_key_versions_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_key_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_key_versions_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_key_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_keys_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_keys_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_import_jobs_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_import_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_import_jobs_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_import_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_key_rings_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_key_rings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_key_rings_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_key_rings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_retired_resources_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_retired_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_retired_resources_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_retired_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_sign_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_sign_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_sign_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_sign_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_verify_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_verify_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_verify_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_verify_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_decrypt_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_decrypt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_decrypt_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_decrypt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_encrypt_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_encrypt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_encrypt_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_encrypt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_restore_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_restore_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_restore_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_restore_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_primary_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_primary_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_primary_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_primary_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/tests/__init__.py
+++ b/packages/google-cloud-kms/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/tests/unit/__init__.py
+++ b/packages/google-cloud-kms/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-kms/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/tests/unit/gapic/kms_v1/__init__.py
+++ b/packages/google-cloud-kms/tests/unit/gapic/kms_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/.flake8
+++ b/packages/google-cloud-language/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/MANIFEST.in
+++ b/packages/google-cloud-language/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language/gapic_version.py
+++ b/packages/google-cloud-language/google/cloud/language/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/gapic_version.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/async_client.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/client.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/base.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/grpc.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/rest.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/rest_base.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/types/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/types/language_service.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/types/language_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/gapic_version.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/async_client.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/client.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/base.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/grpc.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/rest.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/rest_base.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/types/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/types/language_service.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/types/language_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/gapic_version.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/async_client.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/client.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/base.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/grpc.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/rest.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/rest_base.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/types/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/types/language_service.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/types/language_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entities_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entities_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entity_sentiment_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entity_sentiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entity_sentiment_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entity_sentiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_sentiment_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_sentiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_sentiment_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_sentiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_syntax_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_syntax_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_syntax_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_syntax_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_annotate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_annotate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_annotate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_annotate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_classify_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_classify_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_classify_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_classify_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_moderate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_moderate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_moderate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_moderate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entities_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entities_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entity_sentiment_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entity_sentiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entity_sentiment_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entity_sentiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_sentiment_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_sentiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_sentiment_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_sentiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_syntax_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_syntax_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_syntax_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_syntax_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_annotate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_annotate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_annotate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_annotate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_classify_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_classify_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_classify_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_classify_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_moderate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_moderate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_moderate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_moderate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_entities_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_entities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_entities_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_sentiment_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_sentiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_sentiment_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_sentiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_annotate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_annotate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_annotate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_annotate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_classify_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_classify_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_classify_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_classify_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_moderate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_moderate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_moderate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_moderate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/__init__.py
+++ b/packages/google-cloud-language/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/unit/__init__.py
+++ b/packages/google-cloud-language/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-language/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/unit/gapic/language_v1/__init__.py
+++ b/packages/google-cloud-language/tests/unit/gapic/language_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/unit/gapic/language_v1beta2/__init__.py
+++ b/packages/google-cloud-language/tests/unit/gapic/language_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/unit/gapic/language_v2/__init__.py
+++ b/packages/google-cloud-language/tests/unit/gapic/language_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/.flake8
+++ b/packages/google-cloud-licensemanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/MANIFEST.in
+++ b/packages/google-cloud-licensemanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager/__init__.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager/gapic_version.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/gapic_version.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/__init__.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/__init__.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/client.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/pagers.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/__init__.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/base.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/grpc.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/rest.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/rest_base.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/__init__.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/api_entities.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/api_entities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/licensemanager.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/licensemanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_aggregate_usage_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_aggregate_usage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_aggregate_usage_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_aggregate_usage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_create_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_create_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_deactivate_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_deactivate_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_delete_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_delete_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_configuration_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_configuration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_instance_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_instance_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_product_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_product_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_configurations_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_configurations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_configurations_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_configurations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_instances_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_instances_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_products_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_products_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_query_configuration_license_usage_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_query_configuration_license_usage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_query_configuration_license_usage_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_query_configuration_license_usage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_reactivate_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_reactivate_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_update_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_update_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/tests/__init__.py
+++ b/packages/google-cloud-licensemanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/tests/unit/__init__.py
+++ b/packages/google-cloud-licensemanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-licensemanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/tests/unit/gapic/licensemanager_v1/__init__.py
+++ b/packages/google-cloud-licensemanager/tests/unit/gapic/licensemanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/.flake8
+++ b/packages/google-cloud-life-sciences/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/MANIFEST.in
+++ b/packages/google-cloud-life-sciences/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences/__init__.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences/gapic_version.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/gapic_version.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/__init__.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/__init__.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/client.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/__init__.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/base.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/grpc.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/grpc_asyncio.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/rest.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/rest_base.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/types/__init__.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/types/workflows.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/types/workflows.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/samples/generated_samples/lifesciences_v2beta_generated_workflows_service_v2_beta_run_pipeline_sync.py
+++ b/packages/google-cloud-life-sciences/samples/generated_samples/lifesciences_v2beta_generated_workflows_service_v2_beta_run_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/tests/__init__.py
+++ b/packages/google-cloud-life-sciences/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/tests/unit/__init__.py
+++ b/packages/google-cloud-life-sciences/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-life-sciences/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/tests/unit/gapic/lifesciences_v2beta/__init__.py
+++ b/packages/google-cloud-life-sciences/tests/unit/gapic/lifesciences_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/.flake8
+++ b/packages/google-cloud-locationfinder/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/MANIFEST.in
+++ b/packages/google-cloud-locationfinder/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder/__init__.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder/gapic_version.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/gapic_version.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/__init__.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/__init__.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/async_client.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/client.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/pagers.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/__init__.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/base.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/grpc.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/grpc_asyncio.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/rest.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/rest_base.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/__init__.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/cloud_location.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/cloud_location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/service.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_get_cloud_location_async.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_get_cloud_location_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_get_cloud_location_sync.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_get_cloud_location_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_list_cloud_locations_async.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_list_cloud_locations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_list_cloud_locations_sync.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_list_cloud_locations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_search_cloud_locations_async.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_search_cloud_locations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_search_cloud_locations_sync.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_search_cloud_locations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/tests/__init__.py
+++ b/packages/google-cloud-locationfinder/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/tests/unit/__init__.py
+++ b/packages/google-cloud-locationfinder/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-locationfinder/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/tests/unit/gapic/locationfinder_v1/__init__.py
+++ b/packages/google-cloud-locationfinder/tests/unit/gapic/locationfinder_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/.flake8
+++ b/packages/google-cloud-logging/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/MANIFEST.in
+++ b/packages/google-cloud-logging/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging/gapic_version.py
+++ b/packages/google-cloud-logging/google/cloud/logging/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/gapic_version.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/pagers.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/pagers.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/pagers.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/types/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/types/log_entry.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/types/log_entry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/types/logging.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/types/logging.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/types/logging_config.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/types/logging_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/types/logging_metrics.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/types/logging_metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_bucket_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_bucket_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_undelete_bucket_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_undelete_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_undelete_bucket_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_undelete_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_delete_log_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_delete_log_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_delete_log_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_delete_log_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/tests/__init__.py
+++ b/packages/google-cloud-logging/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/tests/unit/__init__.py
+++ b/packages/google-cloud-logging/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-logging/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/tests/unit/gapic/logging_v2/__init__.py
+++ b/packages/google-cloud-logging/tests/unit/gapic/logging_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/.flake8
+++ b/packages/google-cloud-lustre/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/MANIFEST.in
+++ b/packages/google-cloud-lustre/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre/__init__.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre/gapic_version.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/gapic_version.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/__init__.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/__init__.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/client.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/pagers.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/__init__.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/base.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/grpc.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/grpc_asyncio.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/rest.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/rest_base.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/types/__init__.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/types/instance.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/types/lustre.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/types/lustre.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/types/transfer.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/types/transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_create_instance_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_delete_instance_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_export_data_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_get_instance_async.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_get_instance_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_import_data_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_list_instances_async.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_list_instances_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_update_instance_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/tests/__init__.py
+++ b/packages/google-cloud-lustre/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/tests/unit/__init__.py
+++ b/packages/google-cloud-lustre/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-lustre/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/tests/unit/gapic/lustre_v1/__init__.py
+++ b/packages/google-cloud-lustre/tests/unit/gapic/lustre_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/.flake8
+++ b/packages/google-cloud-maintenance-api/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/MANIFEST.in
+++ b/packages/google-cloud-maintenance-api/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api/gapic_version.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/gapic_version.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/async_client.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/client.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/pagers.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/base.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/grpc.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/grpc_asyncio.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/rest.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/rest_base.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/types/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/types/maintenance_service.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/types/maintenance_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/gapic_version.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/async_client.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/client.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/pagers.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/base.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/grpc.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/grpc_asyncio.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/rest.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/rest_base.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/types/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_get_resource_maintenance_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_get_resource_maintenance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_get_resource_maintenance_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_get_resource_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_list_resource_maintenances_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_list_resource_maintenances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_list_resource_maintenances_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_list_resource_maintenances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_summarize_maintenances_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_summarize_maintenances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_summarize_maintenances_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_summarize_maintenances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_get_resource_maintenance_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_get_resource_maintenance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_get_resource_maintenance_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_get_resource_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_list_resource_maintenances_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_list_resource_maintenances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_list_resource_maintenances_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_list_resource_maintenances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_summarize_maintenances_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_summarize_maintenances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_summarize_maintenances_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_summarize_maintenances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/tests/__init__.py
+++ b/packages/google-cloud-maintenance-api/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/tests/unit/__init__.py
+++ b/packages/google-cloud-maintenance-api/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-maintenance-api/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/tests/unit/gapic/maintenance_api_v1/__init__.py
+++ b/packages/google-cloud-maintenance-api/tests/unit/gapic/maintenance_api_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/tests/unit/gapic/maintenance_api_v1beta/__init__.py
+++ b/packages/google-cloud-maintenance-api/tests/unit/gapic/maintenance_api_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/.flake8
+++ b/packages/google-cloud-managed-identities/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/MANIFEST.in
+++ b/packages/google-cloud-managed-identities/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities/__init__.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities/gapic_version.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/gapic_version.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/__init__.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/__init__.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/client.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/pagers.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/__init__.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/base.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/grpc.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/__init__.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/managed_identities_service.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/managed_identities_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/resource.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_attach_trust_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_attach_trust_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_create_microsoft_ad_domain_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_create_microsoft_ad_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_delete_domain_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_delete_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_detach_trust_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_detach_trust_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_get_domain_async.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_get_domain_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_get_domain_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_get_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_list_domains_async.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_list_domains_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_list_domains_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_list_domains_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reconfigure_trust_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reconfigure_trust_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reset_admin_password_async.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reset_admin_password_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reset_admin_password_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reset_admin_password_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_update_domain_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_update_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_validate_trust_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_validate_trust_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/tests/__init__.py
+++ b/packages/google-cloud-managed-identities/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/tests/unit/__init__.py
+++ b/packages/google-cloud-managed-identities/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-managed-identities/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/tests/unit/gapic/managedidentities_v1/__init__.py
+++ b/packages/google-cloud-managed-identities/tests/unit/gapic/managedidentities_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/.flake8
+++ b/packages/google-cloud-managedkafka-schemaregistry/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/MANIFEST.in
+++ b/packages/google-cloud-managedkafka-schemaregistry/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry/gapic_version.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/gapic_version.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/async_client.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/client.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/base.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/grpc.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/rest.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/rest_base.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/schema_registry.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/schema_registry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/schema_registry_resources.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/schema_registry_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_check_compatibility_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_check_compatibility_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_check_compatibility_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_check_compatibility_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_schema_registry_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_schema_registry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_schema_registry_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_schema_registry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_version_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_version_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_config_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_config_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_mode_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_mode_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_mode_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_registry_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_registry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_registry_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_registry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_subject_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_subject_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_subject_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_subject_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_version_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_version_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_context_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_context_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_context_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_context_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_version_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_version_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_config_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_config_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_mode_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_mode_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_mode_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_registry_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_registry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_registry_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_registry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_version_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_version_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_contexts_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_contexts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_contexts_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_contexts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_referenced_schemas_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_referenced_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_referenced_schemas_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_referenced_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_registries_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_registries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_registries_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_registries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_types_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_types_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_versions_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_versions_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_by_schema_id_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_by_schema_id_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_by_schema_id_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_by_schema_id_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_versions_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_versions_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_lookup_version_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_lookup_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_lookup_version_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_lookup_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_config_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_config_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_mode_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_mode_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_mode_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/tests/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/tests/unit/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/tests/unit/gapic/managedkafka_schemaregistry_v1/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/tests/unit/gapic/managedkafka_schemaregistry_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/.flake8
+++ b/packages/google-cloud-managedkafka/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/MANIFEST.in
+++ b/packages/google-cloud-managedkafka/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka/gapic_version.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/gapic_version.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/client.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/pagers.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/base.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/grpc.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/grpc_asyncio.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/rest.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/rest_base.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/client.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/pagers.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/base.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/grpc.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/grpc_asyncio.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/rest.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/rest_base.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/managed_kafka.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/managed_kafka.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/managed_kafka_connect.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/managed_kafka_connect.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/resources.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_add_acl_entry_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_add_acl_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_add_acl_entry_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_add_acl_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connect_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connect_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connect_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connect_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connect_cluster_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connect_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connect_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connect_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connect_clusters_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connect_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connect_clusters_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connect_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connectors_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connectors_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_pause_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_pause_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_pause_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_pause_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_restart_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_restart_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_restart_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_restart_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_resume_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_resume_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_resume_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_resume_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_stop_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_stop_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_stop_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_stop_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connect_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connect_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_acl_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_acl_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_topic_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_topic_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_acl_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_acl_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_consumer_group_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_consumer_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_consumer_group_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_consumer_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_topic_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_topic_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_acl_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_acl_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_cluster_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_consumer_group_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_consumer_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_consumer_group_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_consumer_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_topic_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_topic_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_acls_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_acls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_acls_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_acls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_clusters_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_clusters_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_consumer_groups_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_consumer_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_consumer_groups_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_consumer_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_topics_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_topics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_topics_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_topics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_remove_acl_entry_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_remove_acl_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_remove_acl_entry_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_remove_acl_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_acl_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_acl_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_consumer_group_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_consumer_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_consumer_group_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_consumer_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_topic_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_topic_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/tests/__init__.py
+++ b/packages/google-cloud-managedkafka/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/tests/unit/__init__.py
+++ b/packages/google-cloud-managedkafka/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-managedkafka/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/tests/unit/gapic/managedkafka_v1/__init__.py
+++ b/packages/google-cloud-managedkafka/tests/unit/gapic/managedkafka_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/.flake8
+++ b/packages/google-cloud-media-translation/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/MANIFEST.in
+++ b/packages/google-cloud-media-translation/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation/__init__.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation/gapic_version.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/gapic_version.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/__init__.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/__init__.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/async_client.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/client.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/__init__.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/base.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/grpc.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/types/__init__.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/types/media_translation.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/types/media_translation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/samples/generated_samples/mediatranslation_v1beta1_generated_speech_translation_service_streaming_translate_speech_async.py
+++ b/packages/google-cloud-media-translation/samples/generated_samples/mediatranslation_v1beta1_generated_speech_translation_service_streaming_translate_speech_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/samples/generated_samples/mediatranslation_v1beta1_generated_speech_translation_service_streaming_translate_speech_sync.py
+++ b/packages/google-cloud-media-translation/samples/generated_samples/mediatranslation_v1beta1_generated_speech_translation_service_streaming_translate_speech_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/tests/__init__.py
+++ b/packages/google-cloud-media-translation/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/tests/unit/__init__.py
+++ b/packages/google-cloud-media-translation/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-media-translation/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/tests/unit/gapic/mediatranslation_v1beta1/__init__.py
+++ b/packages/google-cloud-media-translation/tests/unit/gapic/mediatranslation_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/.flake8
+++ b/packages/google-cloud-memcache/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/MANIFEST.in
+++ b/packages/google-cloud-memcache/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache/gapic_version.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/gapic_version.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/client.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/pagers.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/base.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/grpc.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/grpc_asyncio.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/rest.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/rest_base.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/types/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/types/cloud_memcache.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/types/cloud_memcache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/gapic_version.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/client.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/pagers.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/base.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/grpc.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/grpc_asyncio.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/rest.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/rest_base.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/types/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/types/cloud_memcache.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/types/cloud_memcache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_apply_parameters_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_apply_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_create_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_delete_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_get_instance_async.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_get_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_list_instances_async.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_list_instances_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_reschedule_maintenance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_reschedule_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_update_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_update_parameters_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_update_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_apply_parameters_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_apply_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_apply_software_update_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_apply_software_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_create_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_delete_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_get_instance_async.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_get_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_list_instances_async.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_list_instances_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_reschedule_maintenance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_reschedule_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_update_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_update_parameters_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_update_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/tests/__init__.py
+++ b/packages/google-cloud-memcache/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/tests/unit/__init__.py
+++ b/packages/google-cloud-memcache/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-memcache/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/tests/unit/gapic/memcache_v1/__init__.py
+++ b/packages/google-cloud-memcache/tests/unit/gapic/memcache_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/tests/unit/gapic/memcache_v1beta2/__init__.py
+++ b/packages/google-cloud-memcache/tests/unit/gapic/memcache_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/.flake8
+++ b/packages/google-cloud-memorystore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/MANIFEST.in
+++ b/packages/google-cloud-memorystore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore/gapic_version.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/gapic_version.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/client.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/pagers.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/base.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/grpc.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/rest.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/rest_base.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/types/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/types/memorystore.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/types/memorystore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/gapic_version.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/client.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/pagers.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/base.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/grpc.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/rest.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/rest_base.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/types/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/types/memorystore.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/types/memorystore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_backup_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_backup_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_create_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_delete_backup_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_delete_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_export_backup_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_export_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_collection_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_collection_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_certificate_authority_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_certificate_authority_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_instance_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_shared_regional_certificate_authority_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_shared_regional_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_shared_regional_certificate_authority_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_shared_regional_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backup_collections_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backup_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backup_collections_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backup_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backups_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backups_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_instances_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_instances_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_reschedule_maintenance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_reschedule_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_update_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_create_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_delete_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_certificate_authority_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_certificate_authority_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_instance_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_shared_regional_certificate_authority_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_shared_regional_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_shared_regional_certificate_authority_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_shared_regional_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_list_instances_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_list_instances_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_update_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/tests/__init__.py
+++ b/packages/google-cloud-memorystore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/tests/unit/__init__.py
+++ b/packages/google-cloud-memorystore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-memorystore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/tests/unit/gapic/memorystore_v1/__init__.py
+++ b/packages/google-cloud-memorystore/tests/unit/gapic/memorystore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/tests/unit/gapic/memorystore_v1beta/__init__.py
+++ b/packages/google-cloud-memorystore/tests/unit/gapic/memorystore_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/.flake8
+++ b/packages/google-cloud-migrationcenter/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/MANIFEST.in
+++ b/packages/google-cloud-migrationcenter/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter/__init__.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter/gapic_version.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/gapic_version.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/__init__.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/__init__.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/client.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/pagers.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/__init__.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/base.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/grpc.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/rest.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/rest_base.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/types/__init__.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/types/migrationcenter.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/types/migrationcenter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_add_assets_to_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_add_assets_to_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_aggregate_assets_values_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_aggregate_assets_values_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_aggregate_assets_values_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_aggregate_assets_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_delete_assets_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_delete_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_delete_assets_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_delete_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_update_assets_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_update_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_update_assets_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_update_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_import_data_file_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_import_data_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_preference_set_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_preference_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_report_config_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_report_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_source_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_asset_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_asset_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_import_data_file_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_import_data_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_preference_set_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_preference_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_report_config_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_report_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_source_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_asset_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_asset_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_error_frame_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_error_frame_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_error_frame_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_error_frame_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_group_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_data_file_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_data_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_data_file_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_data_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_job_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_preference_set_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_preference_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_preference_set_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_preference_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_config_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_config_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_settings_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_settings_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_source_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_source_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_assets_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_assets_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_error_frames_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_error_frames_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_error_frames_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_error_frames_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_groups_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_groups_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_data_files_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_data_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_data_files_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_data_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_jobs_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_jobs_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_preference_sets_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_preference_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_preference_sets_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_preference_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_report_configs_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_report_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_report_configs_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_report_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_reports_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_reports_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_sources_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_sources_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_remove_assets_from_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_remove_assets_from_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_report_asset_frames_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_report_asset_frames_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_report_asset_frames_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_report_asset_frames_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_run_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_run_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_asset_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_asset_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_preference_set_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_preference_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_settings_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_source_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_validate_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_validate_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/tests/__init__.py
+++ b/packages/google-cloud-migrationcenter/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/tests/unit/__init__.py
+++ b/packages/google-cloud-migrationcenter/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-migrationcenter/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/tests/unit/gapic/migrationcenter_v1/__init__.py
+++ b/packages/google-cloud-migrationcenter/tests/unit/gapic/migrationcenter_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/.flake8
+++ b/packages/google-cloud-modelarmor/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/MANIFEST.in
+++ b/packages/google-cloud-modelarmor/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor/gapic_version.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/gapic_version.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/async_client.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/client.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/pagers.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/base.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/grpc.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/grpc_asyncio.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/rest.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/rest_base.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/types/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/types/service.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/gapic_version.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/async_client.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/client.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/pagers.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/base.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/grpc.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/grpc_asyncio.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/rest.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/rest_base.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/types/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/types/service.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_create_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_create_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_create_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_create_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_delete_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_delete_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_delete_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_delete_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_floor_setting_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_floor_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_floor_setting_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_floor_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_list_templates_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_list_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_list_templates_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_list_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_model_response_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_model_response_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_model_response_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_model_response_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_user_prompt_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_user_prompt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_user_prompt_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_user_prompt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_floor_setting_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_floor_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_floor_setting_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_floor_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_create_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_create_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_create_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_create_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_delete_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_delete_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_delete_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_delete_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_floor_setting_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_floor_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_floor_setting_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_floor_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_list_templates_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_list_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_list_templates_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_list_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_model_response_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_model_response_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_model_response_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_model_response_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_user_prompt_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_user_prompt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_user_prompt_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_user_prompt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_model_response_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_model_response_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_model_response_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_model_response_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_user_prompt_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_user_prompt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_user_prompt_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_user_prompt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_floor_setting_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_floor_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_floor_setting_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_floor_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/tests/__init__.py
+++ b/packages/google-cloud-modelarmor/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/tests/unit/__init__.py
+++ b/packages/google-cloud-modelarmor/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-modelarmor/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/tests/unit/gapic/modelarmor_v1/__init__.py
+++ b/packages/google-cloud-modelarmor/tests/unit/gapic/modelarmor_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/tests/unit/gapic/modelarmor_v1beta/__init__.py
+++ b/packages/google-cloud-modelarmor/tests/unit/gapic/modelarmor_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/.flake8
+++ b/packages/google-cloud-monitoring-dashboards/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/MANIFEST.in
+++ b/packages/google-cloud-monitoring-dashboards/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard/gapic_version.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/gapic_version.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/async_client.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/client.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/pagers.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/base.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/rest.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/rest_base.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/alertchart.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/alertchart.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/collapsible_group.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/collapsible_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/common.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboard.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboard_filter.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboard_filter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboards_service.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboards_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/drilldowns.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/drilldowns.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/error_reporting_panel.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/error_reporting_panel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/incident_list.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/incident_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/layouts.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/layouts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/logs_panel.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/logs_panel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/metrics.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/piechart.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/piechart.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/scorecard.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/scorecard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/section_header.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/section_header.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/service.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/single_view_group.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/single_view_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/table.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/table_display_options.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/table_display_options.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/text.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/text.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/widget.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/widget.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/xychart.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/xychart.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_create_dashboard_async.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_create_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_create_dashboard_sync.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_create_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_delete_dashboard_async.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_delete_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_delete_dashboard_sync.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_delete_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_get_dashboard_async.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_get_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_get_dashboard_sync.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_get_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_list_dashboards_async.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_list_dashboards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_list_dashboards_sync.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_list_dashboards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_update_dashboard_async.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_update_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_update_dashboard_sync.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_update_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/tests/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/tests/unit/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/tests/unit/gapic/monitoring_dashboard_v1/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/tests/unit/gapic/monitoring_dashboard_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/.flake8
+++ b/packages/google-cloud-monitoring-metrics-scopes/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/MANIFEST.in
+++ b/packages/google-cloud-monitoring-metrics-scopes/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope/gapic_version.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/gapic_version.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/client.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/base.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/grpc.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/metrics_scope.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/metrics_scope.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/metrics_scopes.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/metrics_scopes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_create_monitored_project_sync.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_create_monitored_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_delete_monitored_project_sync.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_delete_monitored_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_get_metrics_scope_async.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_get_metrics_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_get_metrics_scope_sync.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_get_metrics_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_list_metrics_scopes_by_monitored_project_async.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_list_metrics_scopes_by_monitored_project_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_list_metrics_scopes_by_monitored_project_sync.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_list_metrics_scopes_by_monitored_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/tests/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/tests/unit/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/tests/unit/gapic/monitoring_metrics_scope_v1/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/tests/unit/gapic/monitoring_metrics_scope_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/.flake8
+++ b/packages/google-cloud-monitoring/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/MANIFEST.in
+++ b/packages/google-cloud-monitoring/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring/gapic_version.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/gapic_version.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/alert.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/alert.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/alert_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/alert_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/common.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/dropped_labels.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/dropped_labels.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/group.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/group_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/group_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/metric.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/metric.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/mutation_record.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/mutation_record.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/notification.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/notification.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/notification_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/notification_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/query_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/query_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/service_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/service_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/snooze.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/snooze.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/snooze_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/snooze_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/span_context.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/span_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/uptime.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/uptime.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/uptime_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/uptime_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_create_alert_policy_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_create_alert_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_create_alert_policy_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_create_alert_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_delete_alert_policy_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_delete_alert_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_delete_alert_policy_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_delete_alert_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_get_alert_policy_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_get_alert_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_get_alert_policy_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_get_alert_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_list_alert_policies_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_list_alert_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_list_alert_policies_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_list_alert_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_update_alert_policy_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_update_alert_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_update_alert_policy_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_update_alert_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_create_group_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_create_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_create_group_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_create_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_delete_group_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_delete_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_delete_group_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_delete_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_get_group_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_get_group_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_group_members_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_group_members_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_group_members_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_group_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_groups_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_groups_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_update_group_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_update_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_update_group_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_metric_descriptor_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_metric_descriptor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_metric_descriptor_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_metric_descriptor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_service_time_series_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_service_time_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_service_time_series_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_service_time_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_time_series_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_time_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_time_series_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_time_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_delete_metric_descriptor_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_delete_metric_descriptor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_delete_metric_descriptor_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_delete_metric_descriptor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_metric_descriptor_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_metric_descriptor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_metric_descriptor_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_metric_descriptor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_monitored_resource_descriptor_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_monitored_resource_descriptor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_monitored_resource_descriptor_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_monitored_resource_descriptor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_metric_descriptors_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_metric_descriptors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_metric_descriptors_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_metric_descriptors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_monitored_resource_descriptors_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_monitored_resource_descriptors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_monitored_resource_descriptors_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_monitored_resource_descriptors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_time_series_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_time_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_time_series_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_time_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_create_notification_channel_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_create_notification_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_create_notification_channel_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_create_notification_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_delete_notification_channel_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_delete_notification_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_delete_notification_channel_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_delete_notification_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_descriptor_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_descriptor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_descriptor_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_descriptor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_verification_code_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_verification_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_verification_code_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_verification_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channel_descriptors_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channel_descriptors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channel_descriptors_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channel_descriptors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channels_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channels_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_send_notification_channel_verification_code_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_send_notification_channel_verification_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_send_notification_channel_verification_code_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_send_notification_channel_verification_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_update_notification_channel_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_update_notification_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_update_notification_channel_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_update_notification_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_verify_notification_channel_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_verify_notification_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_verify_notification_channel_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_verify_notification_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_query_service_query_time_series_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_query_service_query_time_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_query_service_query_time_series_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_query_service_query_time_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_level_objective_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_level_objective_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_level_objective_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_level_objective_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_level_objective_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_level_objective_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_level_objective_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_level_objective_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_level_objective_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_level_objective_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_level_objective_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_level_objective_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_service_level_objectives_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_service_level_objectives_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_service_level_objectives_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_service_level_objectives_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_services_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_services_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_level_objective_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_level_objective_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_level_objective_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_level_objective_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_create_snooze_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_create_snooze_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_create_snooze_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_create_snooze_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_get_snooze_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_get_snooze_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_get_snooze_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_get_snooze_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_list_snoozes_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_list_snoozes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_list_snoozes_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_list_snoozes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_update_snooze_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_update_snooze_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_update_snooze_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_update_snooze_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_create_uptime_check_config_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_create_uptime_check_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_create_uptime_check_config_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_create_uptime_check_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_delete_uptime_check_config_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_delete_uptime_check_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_delete_uptime_check_config_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_delete_uptime_check_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_get_uptime_check_config_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_get_uptime_check_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_get_uptime_check_config_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_get_uptime_check_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_configs_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_configs_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_ips_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_ips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_ips_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_ips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_update_uptime_check_config_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_update_uptime_check_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_update_uptime_check_config_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_update_uptime_check_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/tests/__init__.py
+++ b/packages/google-cloud-monitoring/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/tests/unit/__init__.py
+++ b/packages/google-cloud-monitoring/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-monitoring/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/tests/unit/gapic/monitoring_v3/__init__.py
+++ b/packages/google-cloud-monitoring/tests/unit/gapic/monitoring_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/.flake8
+++ b/packages/google-cloud-netapp/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/MANIFEST.in
+++ b/packages/google-cloud-netapp/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp/__init__.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp/gapic_version.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/gapic_version.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/__init__.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/__init__.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/client.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/pagers.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/__init__.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/base.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/grpc.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/grpc_asyncio.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/rest.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/rest_base.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/__init__.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/active_directory.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/active_directory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup_policy.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup_vault.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup_vault.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/cloud_netapp_service.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/cloud_netapp_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/common.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/host_group.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/host_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/kms.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/kms.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/ontap.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/ontap.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/quota_rule.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/quota_rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/replication.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/replication.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/snapshot.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/snapshot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/storage_pool.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/storage_pool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/volume.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/volume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_active_directory_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_active_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_policy_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_vault_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_host_group_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_host_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_kms_config_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_kms_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_quota_rule_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_quota_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_snapshot_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_storage_pool_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_storage_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_volume_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_active_directory_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_active_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_policy_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_vault_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_host_group_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_host_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_kms_config_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_kms_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_quota_rule_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_quota_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_snapshot_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_storage_pool_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_storage_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_volume_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_encrypt_volumes_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_encrypt_volumes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_establish_peering_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_establish_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_establish_volume_peering_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_establish_volume_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_delete_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_delete_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_delete_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_get_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_get_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_get_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_patch_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_patch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_patch_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_post_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_post_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_post_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_post_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_active_directory_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_active_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_active_directory_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_active_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_policy_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_policy_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_vault_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_vault_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_vault_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_host_group_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_host_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_host_group_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_host_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_kms_config_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_kms_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_kms_config_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_kms_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_quota_rule_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_quota_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_quota_rule_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_quota_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_replication_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_replication_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_snapshot_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_snapshot_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_storage_pool_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_storage_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_storage_pool_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_storage_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_volume_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_volume_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_volume_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_active_directories_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_active_directories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_active_directories_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_active_directories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_policies_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_policies_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_vaults_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_vaults_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_vaults_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_vaults_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backups_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backups_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_host_groups_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_host_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_host_groups_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_host_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_kms_configs_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_kms_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_kms_configs_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_kms_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_quota_rules_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_quota_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_quota_rules_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_quota_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_replications_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_replications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_replications_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_replications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_snapshots_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_snapshots_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_storage_pools_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_storage_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_storage_pools_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_storage_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_volumes_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_volumes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_volumes_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_volumes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_restore_backup_files_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_restore_backup_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_resume_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_resume_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_reverse_replication_direction_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_reverse_replication_direction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_revert_volume_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_revert_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_stop_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_stop_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_switch_active_replica_zone_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_switch_active_replica_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_sync_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_sync_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_active_directory_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_active_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_policy_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_vault_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_host_group_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_host_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_kms_config_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_kms_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_quota_rule_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_quota_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_snapshot_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_storage_pool_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_storage_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_volume_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_validate_directory_service_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_validate_directory_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_verify_kms_config_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_verify_kms_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_verify_kms_config_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_verify_kms_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/tests/__init__.py
+++ b/packages/google-cloud-netapp/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/tests/unit/__init__.py
+++ b/packages/google-cloud-netapp/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-netapp/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/tests/unit/gapic/netapp_v1/__init__.py
+++ b/packages/google-cloud-netapp/tests/unit/gapic/netapp_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/.flake8
+++ b/packages/google-cloud-network-connectivity/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/MANIFEST.in
+++ b/packages/google-cloud-network-connectivity/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity/gapic_version.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/gapic_version.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/common.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/cross_network_automation.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/cross_network_automation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/data_transfer.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/data_transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/hub.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/hub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/internal_range.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/internal_range.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/common.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/hub.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/hub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/gapic_version.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/common.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/data_transfer.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/data_transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/hub.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/hub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/policy_based_routing.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/policy_based_routing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/transport_manager.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/transport_manager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_map_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_policy_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_token_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_class_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_map_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_policy_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_token_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_class_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_class_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_map_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_map_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_policy_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_policy_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_token_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_token_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_classes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_classes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_classes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_classes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_maps_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_maps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_maps_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_maps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_policies_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_policies_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_tokens_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_tokens_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_class_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_connection_map_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_connection_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_connection_policy_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_connection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_create_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_create_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_create_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_create_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_delete_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_delete_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_delete_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_delete_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_destination_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_destination_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_config_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_destinations_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_destinations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_destinations_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_destinations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_configs_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_configs_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_update_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_update_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_update_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_update_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_accept_hub_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_accept_hub_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_accept_spoke_update_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_accept_spoke_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_create_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_create_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_create_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_create_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_delete_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_delete_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_delete_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_delete_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_group_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_group_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_hub_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_hub_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_table_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_table_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_spoke_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_spoke_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_groups_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_groups_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hub_spokes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hub_spokes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hub_spokes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hub_spokes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hubs_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hubs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hubs_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hubs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_route_tables_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_route_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_route_tables_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_route_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_routes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_routes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_spokes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_spokes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_spokes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_spokes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_query_hub_status_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_query_hub_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_query_hub_status_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_query_hub_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_reject_hub_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_reject_hub_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_reject_spoke_update_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_reject_spoke_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_group_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_create_internal_range_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_create_internal_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_delete_internal_range_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_delete_internal_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_get_internal_range_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_get_internal_range_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_get_internal_range_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_get_internal_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_list_internal_ranges_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_list_internal_ranges_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_list_internal_ranges_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_list_internal_ranges_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_update_internal_range_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_update_internal_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_create_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_create_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_delete_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_delete_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_get_policy_based_route_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_get_policy_based_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_get_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_get_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_list_policy_based_routes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_list_policy_based_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_list_policy_based_routes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_list_policy_based_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_create_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_create_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_create_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_create_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_delete_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_delete_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_delete_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_delete_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_hub_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_hub_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_spoke_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_spoke_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_hubs_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_hubs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_hubs_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_hubs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_spokes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_spokes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_spokes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_spokes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_update_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_update_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_update_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_update_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_create_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_create_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_create_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_create_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_delete_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_delete_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_delete_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_delete_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_destination_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_destination_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_config_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_destinations_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_destinations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_destinations_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_destinations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_configs_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_configs_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_update_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_update_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_update_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_update_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_accept_hub_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_accept_hub_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_accept_spoke_update_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_accept_spoke_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_gateway_advertised_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_gateway_advertised_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_gateway_advertised_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_gateway_advertised_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_gateway_advertised_route_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_gateway_advertised_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_gateway_advertised_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_gateway_advertised_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_group_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_group_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_hub_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_hub_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_table_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_table_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_spoke_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_spoke_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_gateway_advertised_routes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_gateway_advertised_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_gateway_advertised_routes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_gateway_advertised_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_groups_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_groups_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hub_spokes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hub_spokes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hub_spokes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hub_spokes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hubs_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hubs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hubs_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hubs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_route_tables_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_route_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_route_tables_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_route_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_routes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_routes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_spokes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_spokes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_spokes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_spokes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_query_hub_status_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_query_hub_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_query_hub_status_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_query_hub_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_reject_hub_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_reject_hub_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_reject_spoke_update_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_reject_spoke_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_gateway_advertised_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_gateway_advertised_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_group_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_create_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_create_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_delete_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_delete_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_get_policy_based_route_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_get_policy_based_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_get_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_get_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_list_policy_based_routes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_list_policy_based_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_list_policy_based_routes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_list_policy_based_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_create_transport_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_create_transport_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_delete_transport_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_delete_transport_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_remote_transport_profile_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_remote_transport_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_remote_transport_profile_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_remote_transport_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_status_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_status_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_transport_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_transport_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_transport_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_transport_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_remote_transport_profiles_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_remote_transport_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_remote_transport_profiles_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_remote_transport_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_transports_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_transports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_transports_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_transports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_update_transport_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_update_transport_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/unit/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1alpha1/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1beta/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/.flake8
+++ b/packages/google-cloud-network-management/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/MANIFEST.in
+++ b/packages/google-cloud-network-management/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management/gapic_version.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/gapic_version.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/client.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/pagers.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/grpc.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/rest.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/rest_base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/client.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/pagers.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/grpc.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/rest.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/rest_base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/client.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/pagers.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/grpc.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/rest.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/rest_base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/connectivity_test.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/connectivity_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/reachability.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/reachability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/trace.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/vpc_flow_logs.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/vpc_flow_logs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/vpc_flow_logs_config.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/vpc_flow_logs_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_create_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_create_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_delete_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_delete_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_get_vpc_flow_logs_config_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_get_vpc_flow_logs_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_get_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_get_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_list_vpc_flow_logs_configs_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_list_vpc_flow_logs_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_list_vpc_flow_logs_configs_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_list_vpc_flow_logs_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_update_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_update_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_create_connectivity_test_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_create_connectivity_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_delete_connectivity_test_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_delete_connectivity_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_get_connectivity_test_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_get_connectivity_test_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_get_connectivity_test_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_get_connectivity_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_list_connectivity_tests_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_list_connectivity_tests_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_list_connectivity_tests_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_list_connectivity_tests_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_rerun_connectivity_test_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_rerun_connectivity_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_update_connectivity_test_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_update_connectivity_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_create_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_create_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_delete_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_delete_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_get_vpc_flow_logs_config_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_get_vpc_flow_logs_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_get_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_get_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_list_vpc_flow_logs_configs_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_list_vpc_flow_logs_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_list_vpc_flow_logs_configs_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_list_vpc_flow_logs_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_query_org_vpc_flow_logs_configs_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_query_org_vpc_flow_logs_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_query_org_vpc_flow_logs_configs_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_query_org_vpc_flow_logs_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_show_effective_flow_logs_configs_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_show_effective_flow_logs_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_show_effective_flow_logs_configs_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_show_effective_flow_logs_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_update_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_update_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/tests/__init__.py
+++ b/packages/google-cloud-network-management/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/tests/unit/__init__.py
+++ b/packages/google-cloud-network-management/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-network-management/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/tests/unit/gapic/network_management_v1/__init__.py
+++ b/packages/google-cloud-network-management/tests/unit/gapic/network_management_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/.flake8
+++ b/packages/google-cloud-network-security/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/MANIFEST.in
+++ b/packages/google-cloud-network-security/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security/gapic_version.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/gapic_version.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/async_client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/address_group.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/address_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/authorization_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/authorization_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/authz_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/authz_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/backend_authentication_config.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/backend_authentication_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/client_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/client_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/common.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/dns_threat_detector.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/dns_threat_detector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/firewall_activation.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/firewall_activation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/gateway_security_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/gateway_security_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/gateway_security_policy_rule.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/gateway_security_policy_rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/intercept.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/intercept.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/mirroring.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/mirroring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/network_security.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/network_security.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_intercept.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_intercept.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_mirroring.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_mirroring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_service.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_threatprevention.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_threatprevention.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_urlfiltering.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_urlfiltering.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/server_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/server_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/tls.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/tls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/tls_inspection_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/tls_inspection_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/url_list.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/url_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/async_client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/authorization_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/authorization_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/authz_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/authz_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/backend_authentication_config.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/backend_authentication_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/client_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/client_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/common.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/dns_threat_detector.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/dns_threat_detector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/firewall_activation.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/firewall_activation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/gateway_security_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/gateway_security_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/gateway_security_policy_rule.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/gateway_security_policy_rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/intercept.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/intercept.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/mirroring.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/mirroring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/network_security.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/network_security.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_intercept.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_intercept.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_mirroring.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_mirroring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_service.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_threatprevention.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_threatprevention.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_urlfiltering.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_urlfiltering.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/server_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/server_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/sse_gateway.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/sse_gateway.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/sse_realm.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/sse_realm.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/tls.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/tls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/tls_inspection_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/tls_inspection_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/url_list.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/url_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/gapic_version.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/async_client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/authorization_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/authorization_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/client_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/client_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/common.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/dns_threat_detector.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/dns_threat_detector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/network_security.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/network_security.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/server_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/server_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/tls.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/tls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_add_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_add_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_clone_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_clone_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_create_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_create_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_delete_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_delete_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_get_address_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_get_address_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_get_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_get_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_group_references_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_group_references_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_group_references_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_group_references_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_remove_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_remove_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_update_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_update_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_create_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_create_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_create_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_create_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_delete_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_delete_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_delete_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_delete_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoint_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoint_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoint_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoint_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoints_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoints_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_update_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_update_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_update_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_update_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployment_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployment_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployment_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployment_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployments_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployments_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_group_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_group_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_group_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_group_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployment_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployment_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployment_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployment_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployments_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployments_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_group_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_group_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_group_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_group_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authorization_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authorization_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authz_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authz_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_backend_authentication_config_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_backend_authentication_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_client_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_client_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_rule_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_server_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_server_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_tls_inspection_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_tls_inspection_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_url_list_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_url_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authorization_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authorization_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authorization_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authorization_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authz_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authz_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authz_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authz_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_backend_authentication_configs_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_backend_authentication_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_backend_authentication_configs_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_backend_authentication_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_client_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_client_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_client_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_client_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policy_rules_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policy_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policy_rules_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policy_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_server_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_server_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_server_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_server_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_tls_inspection_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_tls_inspection_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_tls_inspection_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_tls_inspection_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_url_lists_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_url_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_url_lists_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_url_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_add_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_add_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_clone_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_clone_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_create_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_create_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_delete_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_delete_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_get_address_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_get_address_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_get_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_get_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_group_references_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_group_references_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_group_references_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_group_references_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_remove_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_remove_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_update_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_update_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_create_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_create_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_create_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_create_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_delete_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_delete_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_delete_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_delete_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profile_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profile_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profile_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profile_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profiles_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profiles_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_update_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_update_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_update_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_update_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_create_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_create_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_create_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_create_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_delete_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_delete_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_delete_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_delete_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoint_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoint_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoint_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoint_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoints_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoints_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_update_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_update_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_update_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_update_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployment_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployment_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployment_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployment_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployments_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployments_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_group_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_group_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_group_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_group_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployment_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployment_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployment_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployment_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployments_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployments_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_group_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_group_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_group_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_group_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authorization_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authorization_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authz_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authz_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_backend_authentication_config_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_backend_authentication_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_client_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_client_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_rule_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_server_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_server_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_tls_inspection_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_tls_inspection_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_url_list_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_url_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authorization_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authorization_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authorization_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authorization_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authz_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authz_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authz_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authz_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_backend_authentication_configs_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_backend_authentication_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_backend_authentication_configs_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_backend_authentication_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_client_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_client_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_client_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_client_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policy_rules_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policy_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policy_rules_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policy_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_server_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_server_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_server_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_server_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_tls_inspection_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_tls_inspection_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_tls_inspection_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_tls_inspection_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_url_lists_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_url_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_url_lists_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_url_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_create_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_create_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_create_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_create_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_delete_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_delete_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_delete_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_delete_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profile_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profile_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profile_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profile_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profiles_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profiles_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_update_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_update_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_update_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_update_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_create_partner_sse_gateway_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_create_partner_sse_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_delete_partner_sse_gateway_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_delete_partner_sse_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_partner_sse_gateway_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_partner_sse_gateway_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_partner_sse_gateway_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_partner_sse_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_sse_gateway_reference_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_sse_gateway_reference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_sse_gateway_reference_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_sse_gateway_reference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_partner_sse_gateways_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_partner_sse_gateways_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_partner_sse_gateways_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_partner_sse_gateways_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_sse_gateway_references_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_sse_gateway_references_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_sse_gateway_references_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_sse_gateway_references_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_update_partner_sse_gateway_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_update_partner_sse_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_partner_sse_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_partner_sse_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_sac_attachment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_sac_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_sac_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_sac_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_partner_sse_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_partner_sse_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_sac_attachment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_sac_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_sac_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_sac_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_partner_sse_realm_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_partner_sse_realm_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_partner_sse_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_partner_sse_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_attachment_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_attachment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_realm_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_realm_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_partner_sse_realms_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_partner_sse_realms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_partner_sse_realms_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_partner_sse_realms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_attachments_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_attachments_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_realms_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_realms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_realms_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_realms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_authorization_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_authorization_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_client_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_client_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_server_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_server_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_authorization_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_authorization_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_authorization_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_authorization_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_client_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_client_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_client_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_client_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_server_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_server_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_server_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_server_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/__init__.py
+++ b/packages/google-cloud-network-security/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/unit/__init__.py
+++ b/packages/google-cloud-network-security/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-network-security/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1/__init__.py
+++ b/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1alpha1/__init__.py
+++ b/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1beta1/__init__.py
+++ b/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/.flake8
+++ b/packages/google-cloud-network-services/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/MANIFEST.in
+++ b/packages/google-cloud-network-services/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services/gapic_version.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/gapic_version.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/client.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/pagers.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/base.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/grpc.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/rest.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/rest_base.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/client.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/pagers.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/base.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/grpc.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/rest.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/rest_base.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/common.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/dep.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/dep.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/endpoint_policy.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/endpoint_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/extensibility.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/extensibility.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/gateway.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/gateway.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/grpc_route.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/grpc_route.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/http_route.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/http_route.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/mesh.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/mesh.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/network_services.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/network_services.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/route_view.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/route_view.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/service_binding.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/service_binding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/tcp_route.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/tcp_route.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/tls_route.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/tls_route.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_authz_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_authz_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_edge_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_edge_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_route_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_route_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_traffic_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_traffic_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_authz_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_authz_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_edge_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_edge_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_route_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_route_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_traffic_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_traffic_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_authz_extension_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_authz_extension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_authz_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_authz_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_edge_extension_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_edge_extension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_edge_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_edge_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_route_extension_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_route_extension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_route_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_route_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_traffic_extension_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_traffic_extension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_traffic_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_traffic_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_authz_extensions_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_authz_extensions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_authz_extensions_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_authz_extensions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_edge_extensions_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_edge_extensions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_edge_extensions_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_edge_extensions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_route_extensions_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_route_extensions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_route_extensions_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_route_extensions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_traffic_extensions_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_traffic_extensions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_traffic_extensions_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_traffic_extensions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_authz_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_authz_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_edge_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_edge_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_route_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_route_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_traffic_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_traffic_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_endpoint_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_endpoint_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_gateway_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_grpc_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_grpc_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_http_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_http_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_mesh_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_mesh_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_service_binding_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_service_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_service_lb_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_service_lb_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_tcp_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_tcp_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_tls_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_tls_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_wasm_plugin_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_wasm_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_wasm_plugin_version_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_wasm_plugin_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_endpoint_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_endpoint_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_gateway_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_grpc_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_grpc_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_http_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_http_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_mesh_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_mesh_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_service_binding_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_service_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_service_lb_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_service_lb_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_tcp_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_tcp_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_tls_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_tls_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_wasm_plugin_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_wasm_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_wasm_plugin_version_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_wasm_plugin_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_endpoint_policy_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_endpoint_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_endpoint_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_endpoint_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_route_view_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_route_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_route_view_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_route_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_grpc_route_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_grpc_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_grpc_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_grpc_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_http_route_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_http_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_http_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_http_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_route_view_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_route_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_route_view_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_route_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_binding_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_binding_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_lb_policy_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_lb_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_lb_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_lb_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tcp_route_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tcp_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tcp_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tcp_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tls_route_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tls_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tls_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tls_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_version_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_version_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_endpoint_policies_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_endpoint_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_endpoint_policies_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_endpoint_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateway_route_views_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateway_route_views_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateway_route_views_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateway_route_views_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateways_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateways_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateways_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateways_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_grpc_routes_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_grpc_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_grpc_routes_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_grpc_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_http_routes_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_http_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_http_routes_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_http_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_mesh_route_views_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_mesh_route_views_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_mesh_route_views_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_mesh_route_views_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_meshes_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_meshes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_meshes_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_meshes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_bindings_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_bindings_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_lb_policies_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_lb_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_lb_policies_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_lb_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tcp_routes_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tcp_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tcp_routes_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tcp_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tls_routes_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tls_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tls_routes_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tls_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugin_versions_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugin_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugin_versions_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugin_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugins_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugins_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugins_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugins_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_endpoint_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_endpoint_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_gateway_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_grpc_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_grpc_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_http_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_http_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_mesh_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_mesh_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_service_binding_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_service_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_service_lb_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_service_lb_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_tcp_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_tcp_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_tls_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_tls_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_wasm_plugin_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_wasm_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/tests/__init__.py
+++ b/packages/google-cloud-network-services/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/tests/unit/__init__.py
+++ b/packages/google-cloud-network-services/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-network-services/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/tests/unit/gapic/network_services_v1/__init__.py
+++ b/packages/google-cloud-network-services/tests/unit/gapic/network_services_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/.flake8
+++ b/packages/google-cloud-notebooks/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/MANIFEST.in
+++ b/packages/google-cloud-notebooks/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks/gapic_version.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/gapic_version.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/client.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/pagers.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/grpc.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/client.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/pagers.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/grpc.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/diagnostic_config.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/diagnostic_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/environment.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/environment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/event.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/execution.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/execution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/instance.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/instance_config.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/instance_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/managed_service.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/managed_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/runtime.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/runtime.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/schedule.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/schedule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/service.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/gapic_version.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/client.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/pagers.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/grpc.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/rest.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/rest_base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/environment.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/environment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/instance.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/service.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/gapic_version.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/client.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/pagers.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/grpc.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/rest.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/rest_base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/diagnostic_config.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/diagnostic_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/event.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/gce_setup.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/gce_setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/instance.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/service.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_create_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_create_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_delete_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_delete_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_diagnose_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_diagnose_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_get_runtime_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_get_runtime_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_get_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_get_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_list_runtimes_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_list_runtimes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_list_runtimes_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_list_runtimes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_refresh_runtime_token_internal_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_refresh_runtime_token_internal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_refresh_runtime_token_internal_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_refresh_runtime_token_internal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_report_runtime_event_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_report_runtime_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_reset_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_reset_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_start_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_start_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_stop_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_stop_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_switch_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_switch_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_update_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_update_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_upgrade_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_upgrade_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_execution_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_schedule_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_execution_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_schedule_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_diagnose_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_diagnose_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_environment_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_execution_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_execution_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_health_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_health_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_health_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_schedule_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_schedule_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_is_instance_upgradeable_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_is_instance_upgradeable_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_is_instance_upgradeable_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_is_instance_upgradeable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_environments_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_environments_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_executions_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_executions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_executions_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_executions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_instances_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_instances_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_schedules_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_schedules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_schedules_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_schedules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_register_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_register_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_report_instance_info_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_report_instance_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_reset_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_reset_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_rollback_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_rollback_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_accelerator_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_accelerator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_labels_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_machine_type_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_machine_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_start_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_start_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_stop_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_stop_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_trigger_schedule_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_trigger_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_config_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_metadata_items_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_metadata_items_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_metadata_items_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_metadata_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_shielded_instance_config_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_shielded_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_upgrade_instance_internal_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_upgrade_instance_internal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_upgrade_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_upgrade_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_create_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_create_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_delete_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_delete_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_environment_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_instance_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_is_instance_upgradeable_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_is_instance_upgradeable_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_is_instance_upgradeable_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_is_instance_upgradeable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_environments_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_environments_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_instances_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_instances_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_register_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_register_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_report_instance_info_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_report_instance_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_reset_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_reset_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_accelerator_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_accelerator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_labels_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_machine_type_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_machine_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_start_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_start_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_stop_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_stop_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_upgrade_instance_internal_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_upgrade_instance_internal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_upgrade_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_upgrade_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_check_instance_upgradability_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_check_instance_upgradability_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_check_instance_upgradability_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_check_instance_upgradability_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_create_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_delete_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_diagnose_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_diagnose_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_get_instance_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_get_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_list_instances_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_list_instances_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_reset_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_reset_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_rollback_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_rollback_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_start_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_start_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_stop_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_stop_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_update_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_upgrade_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_upgrade_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/__init__.py
+++ b/packages/google-cloud-notebooks/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/unit/__init__.py
+++ b/packages/google-cloud-notebooks/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-notebooks/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v1/__init__.py
+++ b/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v1beta1/__init__.py
+++ b/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v2/__init__.py
+++ b/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the result of regenerating all packages, but only committing files which have only changed in a single line, and that's a copyright line.
